### PR TITLE
Add missing header guard for Interface.hh

### DIFF
--- a/include/ignition/fuel_tools/Interface.hh
+++ b/include/ignition/fuel_tools/Interface.hh
@@ -15,6 +15,9 @@
  *
 */
 
+#ifndef IGNITION_FUEL_TOOLS_INTERFACE_HH_
+#define IGNITION_FUEL_TOOLS_INTERFACE_HH_
+
 #include <string>
 #include "ignition/fuel_tools/Export.hh"
 #include "ignition/fuel_tools/FuelClient.hh"
@@ -39,3 +42,5 @@ namespace ignition
         const std::string &_uri, ignition::fuel_tools::FuelClient &_client);
   }
 }
+
+#endif


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Noticed it was missing during #248 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
