### PR TITLE
Ignitionrobotics to gazebosim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,26 @@ For a complete list of commands run `ign fuel -h` on the command line.
 ** List all models **
 ```
 $ ign fuel list -t model -r | head
-https://fuel.ignitionrobotics.org/anonymous/test_model_595389531
-https://fuel.ignitionrobotics.org/anonymous/test_model_122023392
-https://fuel.ignitionrobotics.org/anonymous/test_model_429486665
-https://fuel.ignitionrobotics.org/anonymous/test_model_887243621
-https://fuel.ignitionrobotics.org/anonymous/test_model_084900530
-https://fuel.ignitionrobotics.org/anonymous/test_model_240061059
-https://fuel.ignitionrobotics.org/anonymous/test_model_464734097
-https://fuel.ignitionrobotics.org/anonymous/test_model_658598990
-https://fuel.ignitionrobotics.org/anonymous/test_model_834617935
-https://fuel.ignitionrobotics.org/anonymous/test_model_380348669
+https://fuel.gazebosim.org/anonymous/test_model_595389531
+https://fuel.gazebosim.org/anonymous/test_model_122023392
+https://fuel.gazebosim.org/anonymous/test_model_429486665
+https://fuel.gazebosim.org/anonymous/test_model_887243621
+https://fuel.gazebosim.org/anonymous/test_model_084900530
+https://fuel.gazebosim.org/anonymous/test_model_240061059
+https://fuel.gazebosim.org/anonymous/test_model_464734097
+https://fuel.gazebosim.org/anonymous/test_model_658598990
+https://fuel.gazebosim.org/anonymous/test_model_834617935
+https://fuel.gazebosim.org/anonymous/test_model_380348669
 ```
 
 ** Download a model **
 ```
-$ ign fuel download -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance -v 4
+$ ign fuel download -u https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance -v 4
 Downloading model:
   Name: Ambulance
   Owner: OpenRobotics
   Server:
-    URL: https://fuel.ignitionrobotics.org
+    URL: https://fuel.gazebosim.org
     Version: 1.0
 
 Download succeeded.
@@ -60,7 +60,7 @@ Download succeeded.
 
 ** C++ Get List models **
 ```
-  // Create a client (uses https://fuel.ignitionrobotics.org by default)
+  // Create a client (uses https://fuel.gazebosim.org by default)
   ignition::fuel_tools::ClientConfig conf;
   ignition::fuel_tools::FuelClient client(conf);
   ignition::fuel_tools::ModelIter iter = client.Models();
@@ -107,7 +107,7 @@ See issues beginning with [Fuel backend] in the title. Here are two examples.
 ** TODO: Find a model on disk **
 ```
 $ ign fuel locate --name am1
-/home/developer/.ignition/fuel/fuel.ignitionrobotics.org/alice/am1
+/home/developer/.ignition/fuel/fuel.gazebosim.org/alice/am1
 ```
 
 ## Dependencies

--- a/api.md.in
+++ b/api.md.in
@@ -1,6 +1,6 @@
 ## Gazebo @IGN_DESIGNATION_CAP@
 
-Gazebo @IGN_DESIGNATION_CAP@ is a component in Gazebo, a set of libraries
+@IGN_DESIGNATION_CAP@ is a component in Gazebo, a set of libraries
 designed to rapidly develop robot and simulation applications. 
 
 ## License

--- a/api.md.in
+++ b/api.md.in
@@ -1,6 +1,6 @@
-## Ignition @IGN_DESIGNATION_CAP@
+## Gazebo @IGN_DESIGNATION_CAP@
 
-Ignition @IGN_DESIGNATION_CAP@ is a component in Ignition Robotics, a set of libraries
+Gazebo @IGN_DESIGNATION_CAP@ is a component in Gazebo, a set of libraries
 designed to rapidly develop robot and simulation applications. 
 
 ## License

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -7,7 +7,7 @@ servers:
 
   -
     name: ignition
-    url: https://fuel.ignition.org
+    url: https://fuel.ignitionrobotics.org
 
 # Where are the assets stored in disk.
 # cache:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -2,12 +2,12 @@
 # The list of servers.
 servers:
   -
-    name: osrf
-    url: https://fuel.ignitionrobotics.org
+    name: gazebo
+    url: https://fuel.gazebosim.org
 
-  # -
-    # name: another_server
-    # url: https://myserver
+  -
+    name: ignition
+    url: https://fuel.ignition.org
 
 # Where are the assets stored in disk.
 # cache:

--- a/doc/header.html
+++ b/doc/header.html
@@ -6,14 +6,14 @@
     <meta name="keywords" content="$projectname">
     <title>$projectname: $title</title>
     <script type="text/javascript" src="jquery.js"></script>
-    <script type="text/javascript" src="https://ignitionrobotics.org/assets/doxygen/dynsections.js"></script>
+    <script type="text/javascript" src="https://gazebosim.org/assets/doxygen/dynsections.js"></script>
 
     <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.deep_orange-blue.min.css">
     <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 
-    <link href="https://ignitionrobotics.org/assets/doxygen/doxygen.css" rel="stylesheet" type="text/css">
+    <link href="https://gazebosim.org/assets/doxygen/doxygen.css" rel="stylesheet" type="text/css">
   </head>
 
 <body>
@@ -21,7 +21,8 @@
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-drawer">
     <div class="mdl-layout__drawer mdl-color--grey-100 mdl-color-text--blue-grey-50">
       <header class="mdl-color--grey-100">
-        <a href="index.html"><img width="60px" src="https://ignitionrobotics.org/assets/doxygen/ignition_logo.svg"/></a>
+        <a href="index.html"><img width="60px" src="https://gazebosim.org/assets/doxygen/gazebo_logo.svg"/></a>
+
         <h1 class="project_title">$projectname</h1>
         <h2>API Reference</h2>
         <div class="version">
@@ -46,9 +47,9 @@
           <i class="mdl-color-text--grey-400 material-icons"
              role="presentation">insert_drive_file</i>Files</a>
         <a class="mdl-navigation__link" target="_blank"
-           href="http://ignitionrobotics.org">
+           href="http://gazebosim.org">
           <i class="mdl-color-text--grey-400 material-icons"
-             role="presentation">launch</i>Ignition Website</a>
+             role="presentation">launch</i>Gazebo Website</a>
         <a class="mdl-navigation__link" target="_blank"
            href="https://github.com/ignitionrobotics/ign-fuel-tools/issues/new">
           <i class="mdl-color-text--grey-400 material-icons"

--- a/doc/ignition.in
+++ b/doc/ignition.in
@@ -768,7 +768,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = /tmp/gazebo-fuel-tools.warn
+WARN_LOGFILE           = /tmp/gz-fuel-tools.warn
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/doc/ignition.in
+++ b/doc/ignition.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Ignition Fuel Tools"
+PROJECT_NAME           = "Gazebo Fuel Tools"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -768,7 +768,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = /tmp/ignition-fuel-tools.warn
+WARN_LOGFILE           = /tmp/gazebo-fuel-tools.warn
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -781,7 +781,7 @@ WARN_LOGFILE           = /tmp/ignition-fuel-tools.warn
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/README.md \
-                         @CMAKE_SOURCE_DIR@/include/ignition/fuel_tools
+                         @CMAKE_SOURCE_DIR@/include/gz/fuel_tools
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -900,7 +900,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           = "sed -e 's/ignition::fuel_tools:://g'"
+INPUT_FILTER           = "sed -e 's/gz::fuel_tools:://g'"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -1229,7 +1229,7 @@ GENERATE_DOCSET        = NO
 # The default value is: Doxygen generated docs.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_FEEDNAME        = "Ignition FUEL TOOLS API Documentation"
+DOCSET_FEEDNAME        = "Gazebo FUEL TOOLS API Documentation"
 
 # This tag specifies a string that should uniquely identify the documentation
 # set bundle. This should be a reverse domain-name style string, e.g.

--- a/doc/ignition.in
+++ b/doc/ignition.in
@@ -781,7 +781,7 @@ WARN_LOGFILE           = /tmp/gazebo-fuel-tools.warn
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/README.md \
-                         @CMAKE_SOURCE_DIR@/include/gz/fuel_tools
+                         @CMAKE_SOURCE_DIR@/include/ignition/fuel_tools
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -900,7 +900,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           = "sed -e 's/gz::fuel_tools:://g'"
+INPUT_FILTER           = "sed -e 's/ignition::fuel_tools:://g'"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the

--- a/doc/tutorials-header.html
+++ b/doc/tutorials-header.html
@@ -6,14 +6,14 @@
     <meta name="keywords" content="$projectname">
     <title>$projectname: $title</title>
     <script type="text/javascript" src="jquery.js"></script>
-    <script type="text/javascript" src="https://ignitionrobotics.org/assets/doxygen/dynsections.js"></script>
+    <script type="text/javascript" src="https://gazebosim.org/assets/doxygen/dynsections.js"></script>
 
     <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.deep_orange-blue.min.css">
     <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 
-    <link href="https://ignitionrobotics.org/assets/doxygen/tutorials-doxygen.css" rel="stylesheet" type="text/css">
+    <link href="https://gazebosim.org/assets/doxygen/tutorials-doxygen.css" rel="stylesheet" type="text/css">
     <script type="text/javascript" src="resize.js"></script>
     <script type="text/javascript" src="navtreedata.js"></script>
     <script type="text/javascript" src="navtree.js"></script>
@@ -23,7 +23,7 @@
    <div class="mdl-layout mdl-layout--fixed-header mdl-js-layout mdl-color--grey-100">
     <header class="mdl-layout__header mdl-layout__header--scroll mdl-color--blue-grey-700 mdl-color-text--grey-100">
       <div class="mdl-layout__header-row">
-        <a href="index.html"><img width="40px" src="https://ignitionrobotics.org/assets/doxygen/ignition_logo_white.svg"/></a>
+        <a href="index.html"><img width="40px" src="https://gazebosim.org/assets/doxygen/gazebo_logo_white.svg"/></a>
         <span class="mdl-layout-title">$projectname Tutorials</span>
       </div>
     </header>

--- a/doc/tutorials.in
+++ b/doc/tutorials.in
@@ -898,7 +898,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           = "sed -e 's/gz::fuel_tools:://g'"
+INPUT_FILTER           = "sed -e 's/ignition::fuel_tools:://g'"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the

--- a/doc/tutorials.in
+++ b/doc/tutorials.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Ignition Fuel Tools"
+PROJECT_NAME           = "Gazebo Fuel Tools"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -768,7 +768,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = /tmp/ignition-fuel_tools-tutorials.warn
+WARN_LOGFILE           = /tmp/gz-fuel_tools-tutorials.warn
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -898,7 +898,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           = "sed -e 's/ignition::fuel_tools:://g'"
+INPUT_FILTER           = "sed -e 's/gz::fuel_tools:://g'"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the
@@ -1227,7 +1227,7 @@ GENERATE_DOCSET        = NO
 # The default value is: Doxygen generated docs.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_FEEDNAME        = "Ignition Fuel Tools API Documentation"
+DOCSET_FEEDNAME        = "Gazebo Fuel Tools API Documentation"
 
 # This tag specifies a string that should uniquely identify the documentation
 # set bundle. This should be a reverse domain-name style string, e.g.

--- a/example/download.cc
+++ b/example/download.cc
@@ -37,11 +37,11 @@ int main(int argc, char **argv)
   std::string usage("Download a resource.");
   usage += " Usage:\n  ./download <options>\n\n";
   usage += "  Examples:\n"
-    "\t ./download -t model -o OpenRobotics -n Beer\n"
+    "\t ./download -t model -o openrobotics -n beer\n"
     "\t ./download -s https://fuel.gazebosim.org -t world "
-    "-o OpenRobotics"
-    " -n Empty\n"
-    "\t ./download -c /tmp/my_config.yaml -t model -o caguero -n Beer\n";
+    "-o openrobotics"
+    " -n test_shapes\n"
+    "\t ./download -c /tmp/my_config.yaml -t model -o caguero -n beer\n";
 
   gflags::SetUsageMessage(usage);
 

--- a/example/download.cc
+++ b/example/download.cc
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
   usage += " Usage:\n  ./download <options>\n\n";
   usage += "  Examples:\n"
     "\t ./download -t model -o OpenRobotics -n Beer\n"
-    "\t ./download -s https://fuel.ignitionrobotics.org -t world "
+    "\t ./download -s https://fuel.gazebosim.org -t world "
     "-o OpenRobotics"
     " -n Empty\n"
     "\t ./download -c /tmp/my_config.yaml -t model -o caguero -n Beer\n";

--- a/include/ignition/fuel_tools/FuelClient.hh
+++ b/include/ignition/fuel_tools/FuelClient.hh
@@ -184,7 +184,7 @@ namespace ignition
 
       /// \brief Remove a resource, such as a model or world, from Ignition Fuel
       /// \param[in] _uri The full URI of the resource, e.g:
-      /// https://fuel.ignitionrobotics.org/1.0/openrobotcs/model/my_model
+      /// https://fuel.gazebosim.org/1.0/openrobotcs/model/my_model
       /// \param[in] _headers Headers to set on the HTTP request.
       /// \return Result of the delete operation
       public: Result DeleteUrl(const ignition::common::URI &_uri,
@@ -238,7 +238,7 @@ namespace ignition
       /// \brief Download a model from ignition fuel. This will override an
       /// existing local copy of the model.
       /// \param[in] _modelUrl The unique URL of the model to download.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/caguero/models/Beer
+      /// E.g.: https://fuel.gazebosim.org/1.0/caguero/models/Beer
       /// \param[out] _path Path where the model was downloaded.
       /// \return Result of the download operation.
       public: Result DownloadModel(const common::URI &_modelUrl,
@@ -247,7 +247,7 @@ namespace ignition
       /// \brief Download a world from ignition fuel. This will override an
       /// existing local copy of the world.
       /// \param[in] _worldUrl The unique URL of the world to download.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty
+      /// E.g.: https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty
       /// \param[out] _path Path where the world was downloaded.
       /// \return Result of the download operation.
       public: Result DownloadWorld(const common::URI &_worldUrl,
@@ -277,7 +277,7 @@ namespace ignition
 
       /// \brief Check if a model is already present in the local cache.
       /// \param[in] _modelUrl The unique URL of the model on a Fuel server.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/caguero/models/Beer
+      /// E.g.: https://fuel.gazebosim.org/1.0/caguero/models/Beer
       /// \param[out] _path Local path where the model can be found.
       /// \return FETCH_ERROR if not cached, FETCH_ALREADY_EXISTS if cached.
       public: Result CachedModel(const common::URI &_modelUrl,
@@ -285,13 +285,13 @@ namespace ignition
 
       /// \brief Check if a model exists in the cache.
       /// \param[in] _modelUrl The unique URL of the world on a Fuel server.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/caguero/models/Beer
+      /// E.g.: https://fuel.gazebosim.org/1.0/caguero/models/Beer
       /// \return True if the model exists in the cache, false otherwise.
       public: bool CachedModel(const common::URI &_modelUrl);
 
       /// \brief Check if a world is already present in the local cache.
       /// \param[in] _worldUrl The unique URL of the world on a Fuel server.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty
+      /// E.g.: https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty
       /// \param[out] _path Local path where the world can be found.
       /// \return FETCH_ERROR if not cached, FETCH_ALREADY_EXISTS if cached.
       public: Result CachedWorld(const common::URI &_worldUrl,
@@ -299,7 +299,7 @@ namespace ignition
 
       /// \brief Check if a world exists in the cache.
       /// \param[in] _worldUrl The unique URL of the world on a Fuel server.
-      /// E.g.: https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty
+      /// E.g.: https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty
       /// \return True if the world exists in the cache, false otherwise.
       public: bool CachedWorld(const common::URI &_worldUrl);
 

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -53,7 +53,7 @@ class ignition::fuel_tools::ClientConfigPrivate
             this->cacheLocation = "";
             this->configPath = "";
             this->userAgent =
-              "IgnitionFuelTools-" IGNITION_FUEL_TOOLS_VERSION_FULL;
+              "GzFuelTools-" IGNITION_FUEL_TOOLS_VERSION_FULL;
           }
 
   /// \brief A list of servers.
@@ -67,7 +67,7 @@ class ignition::fuel_tools::ClientConfigPrivate
 
   /// \brief Name of the user agent.
   public: std::string userAgent =
-          "IgnitionFuelTools-" IGNITION_FUEL_TOOLS_VERSION_FULL;
+          "GzFuelTools-" IGNITION_FUEL_TOOLS_VERSION_FULL;
 };
 
 //////////////////////////////////////////////////

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -83,7 +83,7 @@ class ignition::fuel_tools::ServerConfigPrivate
           }
 
   /// \brief URL to reach server
-  public: common::URI url{"https://fuel.ignitionrobotics.org"};
+  public: common::URI url{"https://fuel.gazebosim.org"};
 
   /// \brief A key to auth with the server
   public: std::string key = "";
@@ -132,6 +132,7 @@ common::URI ServerConfig::Url() const
 //////////////////////////////////////////////////
 void ServerConfig::SetUrl(const common::URI &_url)
 {
+  std::cout << "\n\nSetting URIL[" << _url.Str() << "]\n\n\n";
   this->dataPtr->url = _url;
 }
 

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -132,7 +132,6 @@ common::URI ServerConfig::Url() const
 //////////////////////////////////////////////////
 void ServerConfig::SetUrl(const common::URI &_url)
 {
-  std::cout << "\n\nSetting URIL[" << _url.Str() << "]\n\n\n";
   this->dataPtr->url = _url;
 }
 

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -98,7 +98,7 @@ TEST(ClientConfig, CustomDefaultConfiguration)
 {
   ClientConfig config;
   ASSERT_EQ(1u, config.Servers().size());
-  EXPECT_EQ("https://fuel.ignitionrobotics.org",
+  EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
 
   std::string defaultCacheLocation = ignition::common::joinPaths(
@@ -135,7 +135,7 @@ TEST(ClientConfig, CustomConfiguration)
   EXPECT_TRUE(config.LoadConfig(testPath));
 
   ASSERT_EQ(3u, config.Servers().size());
-  EXPECT_EQ("https://fuel.ignitionrobotics.org",
+  EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
   EXPECT_EQ("https://api.ignitionfuel.org",
     config.Servers()[1].Url().Str());
@@ -162,10 +162,10 @@ TEST(ClientConfig, RepeatedServerConfiguration)
       << "# The list of servers."                 << std::endl
       << "servers:"                               << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"  << std::endl
       << ""                                       << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"  << std::endl
       << ""                                       << std::endl
       << "# Where are the assets stored in disk." << std::endl
       << "cache:"                                 << std::endl
@@ -313,7 +313,7 @@ TEST(ClientConfig, AsString)
 #else
     EXPECT_NE(str.find(".ignition\\fuel"), std::string::npos);
 #endif
-    EXPECT_NE(str.find("https://fuel.ignitionrobotics.org"), std::string::npos);
+    EXPECT_NE(str.find("https://fuel.gazebosim.org"), std::string::npos);
   }
 
   {

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -123,18 +123,18 @@ TEST(CollectionIdentifier, AsString)
     std::string str =
         "Name: \n"\
         "Owner: \n"\
-        "Unique name: https://fuel.ignitionrobotics.org/collections/\n"
+        "Unique name: https://fuel.gazebosim.org/collections/\n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #else
     std::string str =
         "Name: \n"\
         "Owner: \n"\
-        "Unique name: https://fuel.ignitionrobotics.org/collections\n"
+        "Unique name: https://fuel.gazebosim.org/collections\n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #endif
@@ -161,7 +161,7 @@ TEST(CollectionIdentifier, AsPrettyString)
     CollectionIdentifier id;
     std::string str =
       "\x1B[96m\x1B[1mServer:\x1B[0m\n  "
-      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.ignitionrobotics.org"
+      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.gazebosim.org"
       "\x1B[0m\n  \x1B[96m\x1B[1mVersion: \x1B[0m\x1B[37m1.0\x1B[0m\n";
     EXPECT_EQ(str, id.AsPrettyString());
   }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -56,7 +56,7 @@ using namespace fuel_tools;
 class ignition::fuel_tools::FuelClientPrivate
 {
   /// \brief A model URL,
-  /// E.g.: https://fuel.ignitionrobotics.org/1.0/caguero/models/Beer/2
+  /// E.g.: https://fuel.gazebosim.org/1.0/caguero/models/Beer/2
   /// Where the API version and the model version are optional.
   public: const std::string kModelUrlRegexStr{
     // Method
@@ -75,7 +75,7 @@ class ignition::fuel_tools::FuelClientPrivate
     "([0-9]*|tip)"};
 
   /// \brief A world URL,
-  /// E.g.: https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/1
+  /// E.g.: https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/1
   /// Where the API version and the world version are optional.
   public: const std::string kWorldUrlRegexStr{
     // Method
@@ -141,7 +141,7 @@ class ignition::fuel_tools::FuelClientPrivate
 
   /// \brief A collection URL,
   /// E.g.:
-  /// https://fuel.ignitionrobotics.org/1.0/OpenRobotics/collections/TestColl
+  /// https://fuel.gazebosim.org/1.0/OpenRobotics/collections/TestColl
   /// Where the API version is optional
   public: const std::string kCollectionUrlRegexStr{
     // Method
@@ -1023,6 +1023,9 @@ bool FuelClient::ParseModelUrl(const common::URI &_modelUrl,
   {
     return false;
   }
+
+  if (server == "fuel.ignitionrobotics.org")
+    server = "fuel.gazebosim.org";
 
   // Get remaining server information from config
   _id.Server().SetUrl(common::URI(scheme + "://" + server));

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1024,6 +1024,9 @@ bool FuelClient::ParseModelUrl(const common::URI &_modelUrl,
     return false;
   }
 
+  // Swap `fuel.ignitionrobotics.org` for `fuel.gazebosim.org`. This is
+  // needed for dependency handling. The gazebosim and ignitionrobotics
+  // servers are the same.
   if (server == "fuel.ignitionrobotics.org")
     server = "fuel.gazebosim.org";
 

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -164,10 +164,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/1.0/german/models/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/german/models/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseModelUrl(ignition::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -183,10 +183,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/5.0/german/models/Cardboard Box/6"};
+      "https://fuel.gazebosim.org/5.0/german/models/Cardboard Box/6"};
     EXPECT_TRUE(client.ParseModelUrl(ignition::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -200,10 +200,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box"};
     EXPECT_TRUE(client.ParseModelUrl(ignition::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -219,10 +219,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/tip"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box/tip"};
     EXPECT_TRUE(client.ParseModelUrl(ignition::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -254,28 +254,28 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseModelUrl(ignition::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/banana/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/german/models/Cardboard Box"};
     EXPECT_FALSE(client.ParseModelUrl(ignition::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/99/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/german/models/Cardboard Box"};
     EXPECT_FALSE(client.ParseModelUrl(ignition::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/2/2/german/models"
+      "https://fuel.gazebosim.org/2/2/german/models"
         "/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseModelUrl(ignition::common::URI(url), id));
   }
@@ -290,11 +290,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/"
         "Cordless Drill/tip/files/meshes/cordless_drill.dae"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "cordless drill");
@@ -309,11 +309,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -328,11 +328,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/5.0/OpenRobotics/models/Pine Tree/tip/"
       "files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -345,11 +345,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/models/pine tree/tip/"
+      "https://fuel.gazebosim.org/OpenRobotics/models/pine tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "openrobotics");
@@ -365,11 +365,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/openrobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -415,7 +415,7 @@ TEST_F(FuelClientTest, DownloadModel)
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"};
+        "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -431,7 +431,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
+        "fuel.gazebosim.org", "chapulina", "models", "test box");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -453,7 +453,7 @@ TEST_F(FuelClientTest, DownloadModel)
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/iche033/models/Rescue Randy"};
+        "https://fuel.gazebosim.org/1.0/iche033/models/Rescue Randy"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -469,7 +469,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "iche033", "models", "rescue randy");
+        "fuel.gazebosim.org", "iche033", "models", "rescue randy");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -506,9 +506,9 @@ TEST_F(FuelClientTest, DownloadModel)
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_red_1"};
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_1"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -541,9 +541,9 @@ TEST_F(FuelClientTest, DownloadModel)
   // Download model with a dependency specified within its `model.config`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_2"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_red_2"};
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_2"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_2"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -576,7 +576,7 @@ TEST_F(FuelClientTest, DownloadModel)
   // Try using nonexistent URL
   {
     std::string url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/"
+        "https://fuel.gazebosim.org/1.0/chapulina/models/"
           "Inexistent model"};
     std::string path;
     Result result = client.DownloadModel(common::URI(url), path);
@@ -613,9 +613,9 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_red_1"};
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_1"};
 
     ModelIdentifier id;
     ModelIdentifier depId;
@@ -810,10 +810,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/1.0/german/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -829,10 +829,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/german/worlds/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -848,10 +848,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/5.0/german/worlds/Cardboard Box/6"};
+      "https://fuel.gazebosim.org/5.0/german/worlds/Cardboard Box/6"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -865,10 +865,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "german");
@@ -886,10 +886,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/tip/"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box/tip/"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -918,28 +918,28 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/banana/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/german/worlds/Cardboard Box"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/99/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/german/worlds/Cardboard Box"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/2/2/german/worlds/Cardboard Box"
+      "https://fuel.gazebosim.org/2/2/german/worlds/Cardboard Box"
         "/banana"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
@@ -954,11 +954,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -973,11 +973,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty sky");
@@ -992,11 +992,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/5.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1009,11 +1009,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "openrobotics");
@@ -1029,11 +1029,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1071,7 +1071,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
   ServerConfig server;
   server.SetUrl(ignition::common::URI(
-        "https://fuel.ignitionrobotics.org"));
+        "https://fuel.gazebosim.org"));
 
   ClientConfig config;
   config.AddServer(server);
@@ -1084,7 +1084,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Download world from URL
   {
     // Unversioned URL should get the latest available version
-    common::URI url{"https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+    common::URI url{"https://fuel.gazebosim.org/1.0/OpenRobotics/"
                     "worlds/Test world"};
 
     // Check it is not cached
@@ -1101,7 +1101,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
     // Check it was downloaded to `1`
     auto worldPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world");
+        "fuel.gazebosim.org", "openrobotics", "worlds", "test world");
 
     EXPECT_EQ(path, common::joinPaths(worldPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(worldPath, "2")));
@@ -1120,7 +1120,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Try using nonexistent URL
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Bad world"};
+        "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Bad world"};
     std::string path;
     auto result = client.DownloadWorld(url, path);
     EXPECT_FALSE(result);
@@ -1349,7 +1349,7 @@ TEST_F(FuelClientTest, Models)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     ModelIter iter = client.Models(serverConfig);
     EXPECT_TRUE(iter);
   }
@@ -1383,7 +1383,7 @@ TEST_F(FuelClientTest, Worlds)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     WorldIter iter = client.Worlds(serverConfig);
     EXPECT_TRUE(iter);
   }

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -60,7 +60,7 @@ TEST(Interface, FetchResources)
   {
     // Check it's not cached
     common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"};
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"};
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
@@ -72,20 +72,20 @@ TEST(Interface, FetchResources)
 
     // Check it was downloaded to `2`
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"));
+      "fuel.gazebosim.org", "chapulina", "models", "test box", "2"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2", "model.sdf")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2", "model.config")));
 
     // Check it wasn't downloaded to model root directory
     EXPECT_FALSE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "Test box", "model.config")));
 
     // Check it is cached
@@ -94,7 +94,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"),
+        "fuel.gazebosim.org", "chapulina", "models", "test box", "2"),
         cachedPath);
      }
   }
@@ -103,9 +103,9 @@ TEST(Interface, FetchResources)
   {
     // Check neither file nor its model are cached
     common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Bus/1/"};
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Bus/1/"};
     common::URI modelFileUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Bus/1/files"
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Bus/1/files"
       "/meshes/bus.obj"};
 
     {
@@ -124,25 +124,25 @@ TEST(Interface, FetchResources)
 
     // Check entire model was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1")));
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "models", "bus",
+      "fuel.gazebosim.org", "openrobotics", "models", "bus",
       "1", "meshes", "bus.obj"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
         "openrobotics", "models", "bus", "1", "model.sdf")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "model.config")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "meshes/bus.obj")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "meshes/bus.mtl")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "materials", "textures",
           "bus.png")));
 
@@ -152,7 +152,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1"),
+        "fuel.gazebosim.org", "openrobotics", "models", "bus", "1"),
         cachedPath);
      }
 
@@ -162,7 +162,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1",
+        "fuel.gazebosim.org", "openrobotics", "models", "bus", "1",
         "meshes", "bus.obj"), cachedPath);
      }
   }
@@ -171,7 +171,7 @@ TEST(Interface, FetchResources)
   {
     // Check it's not cached
     common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/worlds/Test world"};
+      "https://fuel.gazebosim.org/1.0/openrobotics/worlds/Test world"};
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
@@ -183,13 +183,13 @@ TEST(Interface, FetchResources)
 
     // Check it was downloaded to `1`
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds",
+      "fuel.gazebosim.org", "openrobotics", "worlds",
       "test world", "2"));
     EXPECT_TRUE(common::exists(common::joinPaths("test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world",
+      "fuel.gazebosim.org", "openrobotics", "worlds", "test world",
       "2")));
     EXPECT_TRUE(common::exists(common::joinPaths("test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world", "2",
+      "fuel.gazebosim.org", "openrobotics", "worlds", "test world", "2",
       "test.world")));
 
     // Check it is cached
@@ -198,7 +198,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world",
+        "fuel.gazebosim.org", "openrobotics", "worlds", "test world",
         "2"), cachedPath);
      }
   }
@@ -207,9 +207,9 @@ TEST(Interface, FetchResources)
   {
     // Check neither file nor its world are cached
     common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"};
+      "https://fuel.gazebosim.org/1.0/chapulina/worlds/Test world/2/"};
     common::URI worldFileUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"
+      "https://fuel.gazebosim.org/1.0/chapulina/worlds/Test world/2/"
       "files/thumbnails/1.png"};
 
     {
@@ -228,13 +228,13 @@ TEST(Interface, FetchResources)
 
     // Check entire world was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "worlds", "test world", "2")));
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2",
+      "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2",
       "thumbnails", "1.png"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "worlds", "test world", "2", "test.world")));
 
     // Check world is cached
@@ -243,7 +243,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2"),
+        "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2"),
         cachedPath);
      }
 
@@ -253,7 +253,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2",
+        "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2",
         "thumbnails", "1.png"), cachedPath);
      }
   }

--- a/src/JSONParser_TEST.cc
+++ b/src/JSONParser_TEST.cc
@@ -176,7 +176,7 @@ TEST(JSONParser, ParseLicenses)
   std::stringstream tmpJsonStr;
 
   // This is the exact return value from
-  // https://fuel.ignitionrobotics.org/1.0/licenses as of April 29th, 2020.
+  // https://fuel.gazebosim.org/1.0/licenses as of April 29th, 2020.
   tmpJsonStr << R"tmpJsonStr([{
     "ID": 1,
     "CreatedAt": "2017-12-19T20:32:48Z",

--- a/src/ModelIdentifier_TEST.cc
+++ b/src/ModelIdentifier_TEST.cc
@@ -153,7 +153,7 @@ TEST(ModelIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: https://fuel.ignitionrobotics.org/models/\n"
+        "Unique name: https://fuel.gazebosim.org/models/\n"
         "Description: \n"
         "File size: 0\n"
         "Upload date: 0\n"
@@ -164,7 +164,7 @@ TEST(ModelIdentifier, AsString)
         "License image URL: \n"
         "Tags: \n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #else
@@ -172,7 +172,7 @@ TEST(ModelIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: https://fuel.ignitionrobotics.org/models\n"
+        "Unique name: https://fuel.gazebosim.org/models\n"
         "Description: \n"
         "File size: 0\n"
         "Upload date: 0\n"
@@ -183,7 +183,7 @@ TEST(ModelIdentifier, AsString)
         "License image URL: \n"
         "Tags: \n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #endif
@@ -221,7 +221,7 @@ TEST(ModelIdentifier, AsPrettyString)
     ModelIdentifier id;
     std::string str =
       "\x1B[96m\x1B[1mServer:\x1B[0m\n  "
-      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.ignitionrobotics.org"
+      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.gazebosim.org"
       "\x1B[0m\n  \x1B[96m\x1B[1mVersion: \x1B[0m\x1B[37m1.0\x1B[0m\n";
     EXPECT_EQ(str, id.AsPrettyString());
   }

--- a/src/ModelIter_TEST.cc
+++ b/src/ModelIter_TEST.cc
@@ -45,7 +45,7 @@ namespace ignition
       public: static ModelIter ModelIterThreeModelIds()
         {
           ignition::fuel_tools::ServerConfig srv;
-          srv.SetUrl(common::URI("https://ignitionrobotics.org"));
+          srv.SetUrl(common::URI("https://gazebosim.org"));
 
           std::vector<ModelIdentifier> ids;
           for (int i = 0; i < 3; i++)
@@ -67,7 +67,7 @@ namespace ignition
       public: static ModelIter ModelIterThreeModels()
         {
           ignition::fuel_tools::ServerConfig srv;
-          srv.SetUrl(common::URI("https://ignitionrobotics.org"));
+          srv.SetUrl(common::URI("https://gazebosim.org"));
 
           std::vector<Model> models;
           for (int i = 0; i < 3; i++)

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -120,10 +120,10 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org/worlds/\n"
+        "Unique name: fuel.gazebosim.org/worlds/\n"
         "Local path: \n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #else
@@ -131,10 +131,10 @@ TEST(WorldIdentifier, AsString)
         "Name: \n"\
         "Owner: \n"\
         "Version: tip\n"\
-        "Unique name: fuel.ignitionrobotics.org\\worlds\n"
+        "Unique name: fuel.gazebosim.org\\worlds\n"
         "Local path: \n"
         "Server:\n"
-        "  URL: https://fuel.ignitionrobotics.org\n"
+        "  URL: https://fuel.gazebosim.org\n"
         "  Version: 1.0\n"
         "  API key: \n";
 #endif
@@ -164,7 +164,7 @@ TEST(WorldIdentifier, AsPrettyString)
     WorldIdentifier id;
     std::string str =
       "\x1B[96m\x1B[1mServer:\x1B[0m\n  "
-      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.ignitionrobotics.org"
+      "\x1B[96m\x1B[1mURL: \x1B[0m\x1B[37mhttps://fuel.gazebosim.org"
       "\x1B[0m\n  \x1B[96m\x1B[1mVersion: \x1B[0m\x1B[37m1.0\x1B[0m\n";
     EXPECT_EQ(str, id.AsPrettyString());
   }

--- a/src/WorldIter_TEST.cc
+++ b/src/WorldIter_TEST.cc
@@ -44,7 +44,7 @@ namespace ignition
       public: static WorldIter WorldIterThreeWorldIds()
         {
           ignition::fuel_tools::ServerConfig srv;
-          srv.SetUrl(ignition::common::URI("https://ignitionrobotics.org"));
+          srv.SetUrl(ignition::common::URI("https://gazebosim.org"));
 
           std::vector<WorldIdentifier> ids;
           for (int i = 0; i < 3; i++)

--- a/src/cmd/cmdfuel.rb.in
+++ b/src/cmd/cmdfuel.rb.in
@@ -72,7 +72,7 @@ SUBCOMMANDS = {
   "Available Options:                                                      \n"\
   "  -u [--url] arg           URL of the server that should receive        \n"\
   "                           the model. If unspecified, the server will be\n"\
-  "                           https://fuel.ignitionrobotics.org.           \n"\
+  "                           https://fuel.gazebosim.org.           \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
   "                           --header 'authorization: Bearer JWT'.        \n" +
   COMMON_OPTIONS,
@@ -84,7 +84,7 @@ SUBCOMMANDS = {
   "                                                                        \n"\
   "Available Options:                                                      \n"\
   "  -u [--url] arg           Full resource URL, such as:                  \n"\
-  "                           https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Ambulance\n"\
+  "                           https://fuel.gazebosim.org/1.0/openrobotics/models/Ambulance\n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
   "                           --header 'authorization: Bearer JWT'.        \n"\
   "  -j [--jobs] arg          Number of parallel downloads (default: 1,    \n"\
@@ -104,7 +104,7 @@ SUBCOMMANDS = {
   "  -m [--model] arg         Path to directory containing the model.      \n"\
   "  -u [--url] arg           URL of the server that should receive        \n"\
   "                           the model. If unspecified, the server will be\n"\
-  "                           https://fuel.ignitionrobotics.org.           \n"\
+  "                           https://fuel.gazebosim.org.           \n"\
   "  -p [--private]           Use this argument to make the model private. \n"\
   "  -b [--public]            Use this argument to make the model public.  \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
@@ -121,7 +121,7 @@ SUBCOMMANDS = {
   "  -o [--owner] arg         Return only resources for given owner.       \n"\
   "  -u [--url] arg           URL of a server the resource comes from,     \n"\
   "                           if unspecified, it will be                   \n"\
-  "                           https://fuel.ignitionrobotics.org.           \n"\
+  "                           https://fuel.gazebosim.org.           \n"\
   "  -r [--raw]               Machine-friendly output.                     \n" +
   COMMON_OPTIONS,
 
@@ -148,7 +148,7 @@ SUBCOMMANDS = {
   "                           multiple models each in a subdirectory.      \n"\
   "  -u [--url] arg           URL of the server that should receive        \n"\
   "                           the model. If unspecified, the server will be\n"\
-  "                           https://fuel.ignitionrobotics.org.           \n"\
+  "                           https://fuel.gazebosim.org.           \n"\
   "  -p [--private]           Use this argument to make the model private. \n"\
   "                           Otherwise, the model will be public.         \n"\
   "  --header arg             Set an HTTP header, such as                  \n"\
@@ -248,12 +248,12 @@ class Cmd
     case options['subcommand']
     when 'delete'
       if options['url'] == ''
-        puts "Missing resource URL (e.g. --url https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance)."
+        puts "Missing resource URL (e.g. --url https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance)."
         exit(-1)
       end
     when 'download'
       if options['url'] == ''
-        puts "Missing resource URL (e.g. --url https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance)."
+        puts "Missing resource URL (e.g. --url https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance)."
         exit(-1)
       end
 
@@ -294,12 +294,12 @@ class Cmd
         exit(-1)
       end
       if options['url'] == ''
-        puts "Missing URL (e.g. --url https://fuel.ignitionrobotics.org)."
+        puts "Missing URL (e.g. --url https://fuel.gazebosim.org)."
         exit(-1)
       end
     when 'edit'
       if options['url'] == ''
-        puts "Missing resource URL (e.g. --url https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Ambulance)."
+        puts "Missing resource URL (e.g. --url https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ambulance)."
         exit(-1)
       end
     end

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -85,7 +85,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int upload(const char *_path,
 ///
 /// Example usage, including a private access token which is required:
 ///
-/// `ign fuel delete -u https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Ambulance --header "Private-Token: <access_token>"` // NOLINT
+/// `ign fuel delete -u https://fuel.gazebosim.org/1.0/openrobotics/models/Ambulance --header "Private-Token: <access_token>"` // NOLINT
 ///
 /// \param[in] _url Resource URL.
 /// \param[in] _header An HTTP header.
@@ -112,7 +112,7 @@ extern "C" IGNITION_FUEL_TOOLS_VISIBLE int pbtxt2Config(const char *_path);
 ///
 /// Example usage, including a private access token which is required:
 ///
-/// `ign fuel edit -u https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Ambulance --header "Private-Token: <access_token>"` --public // NOLINT
+/// `ign fuel edit -u https://fuel.gazebosim.org/1.0/openrobotics/models/Ambulance --header "Private-Token: <access_token>"` --public // NOLINT
 ///
 /// \param[in] _url Resource URL.
 /// \param[in] _header An HTTP header.

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -99,7 +99,7 @@ TEST(CmdLine,
     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListConfigServerUgly))
 {
   auto output = custom_exec_str(g_listCmd + " -t model --raw");
-  EXPECT_NE(output.find("https://fuel.ignitionrobotics.org/1.0/"),
+  EXPECT_NE(output.find("https://fuel.gazebosim.org/1.0/"),
             std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;
 }
@@ -110,16 +110,16 @@ TEST(CmdLine,
     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListCustomServerPretty))
 {
   auto output = custom_exec_str(
-      g_listCmd + " -t model -u https://staging-fuel.ignitionrobotics.org");
+      g_listCmd + " -t model -u https://staging-fuel.gazebosim.org");
 
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_NE(output.find("owners"), std::string::npos) << output;
   EXPECT_NE(output.find("models"), std::string::npos) << output;
 
-  EXPECT_EQ(output.find("https://fuel.ignitionrobotics.org"), std::string::npos)
+  EXPECT_EQ(output.find("https://fuel.gazebosim.org"), std::string::npos)
       << output;
-  EXPECT_EQ(output.find("https://staging-fuel.ignitionrobotics.org/1.0/"),
+  EXPECT_EQ(output.find("https://staging-fuel.gazebosim.org/1.0/"),
       std::string::npos) << output;
 }
 
@@ -128,8 +128,8 @@ TEST(CmdLine,
 TEST(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WorldListConfigServerUgly))
 {
   auto output = custom_exec_str(g_listCmd +
-      " -t world --raw -u https://staging-fuel.ignitionrobotics.org");
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+      " -t world --raw -u https://staging-fuel.gazebosim.org");
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;
 }
@@ -140,9 +140,9 @@ TEST(CmdLine,
     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WorldListCustomServerPretty))
 {
   auto output = custom_exec_str(
-      g_listCmd + " -t world -u https://staging-fuel.ignitionrobotics.org");
+      g_listCmd + " -t world -u https://staging-fuel.gazebosim.org");
 
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_NE(output.find("owners"), std::string::npos) << output;
   EXPECT_NE(output.find("worlds"), std::string::npos) << output;

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -95,7 +95,7 @@ TEST_F(CmdLine, ModelListConfigServerUgly)
 {
   EXPECT_TRUE(listModels("", "", "true"));
 
-  EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -106,20 +106,20 @@ TEST_F(CmdLine, ModelListConfigServerUgly)
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_F(CmdLine, ModelListConfigServerPretty)
 {
-  EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org"));
+  EXPECT_TRUE(listModels("https://staging-fuel.gazebosim.org"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("models"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -128,11 +128,11 @@ TEST_F(CmdLine, ModelListConfigServerPretty)
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_F(CmdLine, ModelListConfigServerPrettyOwner)
 {
-  EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org",
+  EXPECT_TRUE(listModels("https://staging-fuel.gazebosim.org",
       "openrobotics"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("1 owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -143,10 +143,10 @@ TEST_F(CmdLine, ModelListConfigServerPrettyOwner)
   EXPECT_EQ(this->stdOutBuffer.str().find("20 models"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -178,7 +178,7 @@ TEST_F(CmdLine, ModelDownloadUnversioned)
 {
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"));
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"));
 
   // Check output
   EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
@@ -187,13 +187,13 @@ TEST_F(CmdLine, ModelDownloadUnversioned)
 
   // Check files
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box", "2", "model.sdf")));
 }
 
@@ -212,7 +212,7 @@ TEST_F(CmdLine, DownloadConfigCache)
   ofs << "---"                                    << std::endl
       << "servers:"                               << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"  << std::endl
       << ""                                       << std::endl
       << "cache:"                                 << std::endl
       << "  path: " << this->testCachePath << std::endl
@@ -222,7 +222,7 @@ TEST_F(CmdLine, DownloadConfigCache)
 
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box",
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box",
       testPath.c_str()));
 
   // Check output
@@ -232,7 +232,7 @@ TEST_F(CmdLine, DownloadConfigCache)
 
   // Check files
   auto modelPath = common::joinPaths(this->testCachePath,
-      "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
+      "fuel.gazebosim.org", "chapulina", "models", "test box");
   EXPECT_TRUE(common::isDirectory(modelPath));
   EXPECT_TRUE(common::isDirectory(common::joinPaths(modelPath, "2")));
   EXPECT_TRUE(common::isFile(common::joinPaths(modelPath, "2",
@@ -255,10 +255,10 @@ TEST_F(CmdLine, WorldListFail)
 TEST_F(CmdLine, WorldListConfigServerUgly)
 {
   EXPECT_TRUE(listWorlds(
-        "https://staging-fuel.ignitionrobotics.org", "", "true"));
+        "https://staging-fuel.gazebosim.org", "", "true"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -269,31 +269,31 @@ TEST_F(CmdLine, WorldListConfigServerUgly)
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
 TEST_F(CmdLine, WorldListConfigServerPretty)
 {
-  EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org"));
+  EXPECT_TRUE(listWorlds("https://staging-fuel.gazebosim.org"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
+        "https://staging-fuel.gazebosim.org"), std::string::npos)
     << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 TEST_F(CmdLine, WorldListCustomServerPrettyOwner)
 {
-  EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org",
+  EXPECT_TRUE(listWorlds("https://staging-fuel.gazebosim.org",
       "openrobotics"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
+        "https://staging-fuel.gazebosim.org"), std::string::npos)
     << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -302,10 +302,10 @@ TEST_F(CmdLine, WorldListCustomServerPrettyOwner)
   EXPECT_EQ(this->stdOutBuffer.str().find("20 worlds"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -339,7 +339,7 @@ TEST_F(CmdLine, WorldDownloadUnversioned)
 {
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test world"));
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Test world"));
 
   // Check output
   EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
@@ -348,13 +348,13 @@ TEST_F(CmdLine, WorldDownloadUnversioned)
 
   // Check files
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 }
 
@@ -373,7 +373,7 @@ TEST_P(DownloadCollectionTest, AllItems)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, nullptr, GetParam()));
 
@@ -385,46 +385,46 @@ TEST_P(DownloadCollectionTest, AllItems)
   // Check files
   // Model: Backpack
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
      "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
 }
 
@@ -436,7 +436,7 @@ TEST_P(DownloadCollectionTest, Models)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, "model", GetParam()));
 
@@ -448,34 +448,34 @@ TEST_P(DownloadCollectionTest, Models)
   // Check files
   // Model: Backpack
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
 
   // World: Test World 2
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world2")));
 }
 
@@ -487,7 +487,7 @@ TEST_P(DownloadCollectionTest, Worlds)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, "world", GetParam()));
 
@@ -499,33 +499,33 @@ TEST_P(DownloadCollectionTest, Worlds)
   // Check files
   // Model: Backpack
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
 
   // Model: TEAMBASE
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
 
   // World: Test World
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
 }

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -1,9 +1,8 @@
 \page tutorials Tutorials
 
-Welcome to the Ignition @IGN_DESIGNATION_CAP@ tutorials. These tutorials
+Welcome to the Gazebo @IGN_DESIGNATION_CAP@ tutorials. These tutorials
 will guide you through the process of understanding the capabilities of the
-Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
-
+Gazebo @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 
 **The tutorials**
 

--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -15,7 +15,7 @@ Ignition Fuel Tools accepts a YAML file with the following syntax:
 # The list of servers.
 servers:
   -
-    url: https://fuel.ignitionrobotics.org
+    url: https://fuel.gazebosim.org
     private-token: <your private token>
 
   # -
@@ -47,7 +47,7 @@ Create a file `/tmp/my_config.yaml` with the following content:
 # The list of servers.
 servers:
   -
-    url: https://fuel.ignitionrobotics.org
+    url: https://fuel.gazebosim.org
 
 # Where are the assets stored in disk.
 cache:
@@ -93,7 +93,7 @@ And now the fun part, execute it:
 ```
 
 Verify that you have the model in
-`/tmp/ignition/fuel/fuel.ignitionrobotics.org/caguero/models/Beer`,
+`/tmp/ignition/fuel/fuel.gazebosim.org/caguero/models/Beer`,
 as you configured in your YAML file.
 
 ## Walkthrough

--- a/tutorials/03_command_line.md
+++ b/tutorials/03_command_line.md
@@ -18,9 +18,9 @@ type, such as `model` or `world` as follows:
 You should see a list such as:
 
 ```
-Fetching world list from https://fuel.ignitionrobotics.org...
+Fetching world list from https://fuel.gazebosim.org...
 Received world list (took 350ms).
-https://fuel.ignitionrobotics.org
+https://fuel.gazebosim.org
 ├── OpenRobotics
 │   ├── Empty
 │   └── Shapes
@@ -30,7 +30,7 @@ https://fuel.ignitionrobotics.org
 
 By default, Fuel will list resources from all the servers listed in your
 `config.yaml` file. See the
-[configuration tutorial](https://ignitionrobotics.org/tutorials/fuel_tools/1.0/md__data_ignition_ign-fuel-tools_tutorials_02_configuration.html)
+[configuration tutorial](https://gazebosim.org/tutorials/fuel_tools/1.0/md__data_ignition_ign-fuel-tools_tutorials_02_configuration.html)
 for more details.
 
 > **Tip**: If you want to see resources from a different Fuel server, add it to
@@ -50,9 +50,9 @@ a way that's easier for scripts to parse. For example, try:
 And you'll get a list of the world URLs similar to the one below:
 
 ```
-https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty
-https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Shapes
-https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Shapes%20copy
+https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty
+https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Shapes
+https://fuel.gazebosim.org/1.0/chapulina/worlds/Shapes%20copy
 ```
 
 ### By owner
@@ -70,7 +70,7 @@ computer. We use the `ign fuel download` tool for this.
 We learned above how to get resource URLs. Now we can use these URLs to download
 them. For example, try:
 
-`ign fuel download -v 4 -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty`
+`ign fuel download -v 4 -u https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty`
 
 Note that we passed the `-v 4` option so we get a verbose output. You should see something like:
 
@@ -79,12 +79,12 @@ Downloading world:
   Name: Empty
   Owner: OpenRobotics
   Server:
-    URL: https://fuel.ignitionrobotics.org
+    URL: https://fuel.gazebosim.org
     Version: 1.0
 
-[Msg] Downloading world [fuel.ignitionrobotics.org/OpenRobotics/worlds/Empty]
+[Msg] Downloading world [fuel.gazebosim.org/OpenRobotics/worlds/Empty]
 [Msg] Saved world at:
-  /home/louise/.ignition/fuel/fuel.ignitionrobotics.org/OpenRobotics/worlds/Empty/1
+  /home/louise/.ignition/fuel/fuel.gazebosim.org/OpenRobotics/worlds/Empty/1
 Download succeeded.
 ```
 
@@ -96,14 +96,14 @@ If the model is privated you can create a config file with your token. For examp
 # The list of servers.
 servers:
   -
-    url: https://fuel.ignitionrobotics.org
+    url: https://fuel.gazebosim.org
     private-token: <your private token>
 ```
 
 Then try to download the model:
 
 ```bash
-ign fuel download -v 4 -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty -c /tmp/my_config.yaml
+ign fuel download -v 4 -u https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty -c /tmp/my_config.yaml
 ```
 
 Worlds downloaded with the tool get conveniently organized into the same
@@ -113,7 +113,7 @@ directory, which we call the "local cache". The path is broken down as follows:
 
 > **Tip**: You can change the local cache path in `config.yaml`.
 
-> **Tip**: You can also use other tools such as `wget` to download a zipped file of a world, just add `.zip` to the end of the URL, for example: `wget https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty.zip`.
+> **Tip**: You can also use other tools such as `wget` to download a zipped file of a world, just add `.zip` to the end of the URL, for example: `wget https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty.zip`.
 
 ## Edit resources
 
@@ -138,11 +138,11 @@ access.
 Use the `-p` option to make a resources private. For example:
 
 ```
-ign fuel edit -p -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty --header 'Private-token: YOUR_TOKEN'
+ign fuel edit -p -u https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty --header 'Private-token: YOUR_TOKEN'
 ```
 
 Use the `-b` option to make a resource public. For example:
 
 ```
-ign fuel edit -b -u https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty --header 'Private-token: YOUR_TOKEN'
+ign fuel edit -b -u https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty --header 'Private-token: YOUR_TOKEN'
 ```

--- a/tutorials/04_cpp_api.md
+++ b/tutorials/04_cpp_api.md
@@ -44,7 +44,7 @@ You should see the name of the server followed by its list of models. Here's an
 example:
 
 ```
-[https://fuel.ignitionrobotics.org]
+[https://fuel.gazebosim.org]
 
   Beer
   Wastebasket
@@ -117,7 +117,7 @@ License name: Creative Commons - Attribution
 License URL: http://creativecommons.org/licenses/by/4.0
 License image URL: https://i.creativecommons.org/l/by/4.0/88x31.png
 Server:
-  URL: https://fuel.ignitionrobotics.org
+  URL: https://fuel.gazebosim.org
   Version: 1.0
 ```
 

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -2,7 +2,7 @@
 
 Ignition Fuel Tools provides both a command line tool and a C++ API which allow
 interacting with Ignition Fuel web servers such as
-[https://app.ignitionrobotics.org](https://app.ignitionrobotics.org) and their hosted
+[https://app.gazebosim.org](https://app.gazebosim.org) and their hosted
 simulation resources.
 
 ## Simulation resources


### PR DESCRIPTION
## Summary

**DRAFT** I'm experimenting with changing the fuel servers.

This changes the default Fuel server from `fuel.ignitionrobotics.org` to `fuel.gazebosim.org`.

Additionally, requests to the `fuel.ignitionrobotics.org` server are changed to `fuel.gazebosim.org`. This is needed in order to support models that have dependencies, which are all using the `fuel.ignitionrobotics.org` server name. This should be okay since `fuel.ignitionrobotics.org` and `fuel.gazebosim.org` are the same. The downside is that users transitioning from Ignition to Gazebo will have two folders: 
1. `~/.ignition/fuel/fuel.ignitionrobotics.org`
2. `~/.ignition/fuel/fuel.gazebosim.org`.

Note that I'm not changing the `~/.ignition` base directory since that seemed like too major of a change for a released version of fuel tools.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.