### PR TITLE
Disable staging-fuel.ignitionrobotics.org test

### DIFF
--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -106,8 +106,9 @@ TEST(CmdLine,
 
 /////////////////////////////////////////////////
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/113
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
 TEST(CmdLine,
-    IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListCustomServerPretty))
+    DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(ModelListCustomServerPretty))
 {
   auto output = custom_exec_str(
       g_listCmd + " -t model -u https://staging-fuel.ignitionrobotics.org");
@@ -136,8 +137,9 @@ TEST(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WorldListConfigServerUgly))
 
 /////////////////////////////////////////////////
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/113
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
 TEST(CmdLine,
-    IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WorldListCustomServerPretty))
+    DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(WorldListCustomServerPretty))
 {
   auto output = custom_exec_str(
       g_listCmd + " -t world -u https://staging-fuel.ignitionrobotics.org");

--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -104,7 +104,9 @@ TEST_F(CmdLine, ModelListConfigServerUgly)
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST_F(CmdLine, ModelListConfigServerPretty)
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
+TEST_F(CmdLine,
+       DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(ModelListConfigServerPretty))
 {
   EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org"));
 
@@ -126,7 +128,9 @@ TEST_F(CmdLine, ModelListConfigServerPretty)
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST_F(CmdLine, ModelListConfigServerPrettyOwner)
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
+TEST_F(CmdLine,
+       DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(ModelListConfigServerPrettyOwner))
 {
   EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org",
       "openrobotics"));
@@ -252,7 +256,9 @@ TEST_F(CmdLine, WorldListFail)
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST_F(CmdLine, WorldListConfigServerUgly)
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
+TEST_F(CmdLine,
+       DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(WorldListConfigServerUgly))
 {
   EXPECT_TRUE(listWorlds(
         "https://staging-fuel.ignitionrobotics.org", "", "true"));
@@ -267,7 +273,9 @@ TEST_F(CmdLine, WorldListConfigServerUgly)
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
-TEST_F(CmdLine, WorldListConfigServerPretty)
+// https://github.com/gazebosim/gz-fuel-tools/issues/254
+TEST_F(CmdLine,
+       DETAIL_IGN_UTILS_ADD_DISABLED_PREFIX(WorldListConfigServerPretty))
 {
   EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org"));
 


### PR DESCRIPTION
## Summary
Disables tests being caused by https://github.com/gazebosim/gz-fuel-tools/issues/254.

## Checklist
- [x] Signed all commits for DCO
- [x] Added (actually removed) tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

