### PR TITLE
Fix segfault on Windows

### DIFF
--- a/src/ign_src_TEST.cc
+++ b/src/ign_src_TEST.cc
@@ -386,9 +386,11 @@ TEST_P(DownloadCollectionTest, AllItems)
                   nullptr, nullptr, nullptr, GetParam()));
 
   // Check output
-  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
-      std::string::npos) << this->stdOutBuffer.str();
-  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
+  auto resultStr = this->stdOutBuffer.str();
+  auto errorStr = this->stdErrBuffer.str();
+  EXPECT_NE(resultStr.find("Download succeeded"),
+      std::string::npos) << resultStr;
+  EXPECT_TRUE(errorStr.empty()) << errorStr;
 
   // Check files
   // Model: Backpack
@@ -449,9 +451,11 @@ TEST_P(DownloadCollectionTest, Models)
                   nullptr, nullptr, "model", GetParam()));
 
   // Check output
-  EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
-      std::string::npos) << this->stdOutBuffer.str();
-  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
+  auto resultStr = this->stdOutBuffer.str();
+  auto errorStr = this->stdErrBuffer.str();
+  EXPECT_NE(resultStr.find("Download succeeded"),
+      std::string::npos) << resultStr;
+  EXPECT_TRUE(errorStr.empty()) << errorStr;
 
   // Check files
   // Model: Backpack


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

## Summary
This is just a wild guess attempt to solve the test segfaulting on windows shown here:
https://build.osrfoundation.org/job/ign_fuel-tools-pr-win/210/
and on the buildfarm jobs: https://build.osrfoundation.org/job/ign_fuel-tools-ign-4-win/18/testReport/

If it doesn't solve the segfault I'll open an issue and mark this PR as draft.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> Fixed test**
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
