### PR TITLE
Disable failing windows tests issue #231

### DIFF
--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <ignition/common/Console.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/CollectionIdentifier.hh"
@@ -43,7 +44,8 @@ TEST(CollectionIdentifier, SetFields)
 
 /////////////////////////////////////////////////
 /// \brief Unique Name
-TEST(CollectionIdentifier, UniqueName)
+// See https://github.com/gazebosim/gz-fuel-tools/issues/231
+TEST(CollectionIdentifier, IGN_UTILS_TEST_DISABLED_ON_WIN32(UniqueName))
 {
   ignition::fuel_tools::ServerConfig srv1;
   srv1.SetUrl(common::URI("https://localhost:8001/"));

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -672,7 +672,8 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
 // https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
-TEST_F(FuelClientTest, CachedModel)
+// See https://github.com/gazebosim/gz-fuel-tools/issues/231
+TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(CachedModel))
 {
   // Configure to use binary path as cache and populate it
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));

--- a/src/LocalCache_TEST.cc
+++ b/src/LocalCache_TEST.cc
@@ -224,7 +224,8 @@ class LocalCacheTest : public ::testing::Test
 
 /////////////////////////////////////////////////
 /// \brief Iterate through all models in cache
-TEST_F(LocalCacheTest, AllModels)
+// See https://github.com/gazebosim/gz-fuel-tools/issues/231
+TEST_F(LocalCacheTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(AllModels))
 {
   ASSERT_EQ(0, ChangeDirectory(PROJECT_BINARY_PATH));
   common::removeAll("test_cache");

--- a/src/ModelIdentifier_TEST.cc
+++ b/src/ModelIdentifier_TEST.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <ignition/common/Console.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "ignition/fuel_tools/ClientConfig.hh"
 #include "ignition/fuel_tools/ModelIdentifier.hh"
@@ -55,7 +56,8 @@ TEST(ModelIdentifier, SetFields)
 
 /////////////////////////////////////////////////
 /// \brief Unique Name
-TEST(ModelIdentifier, UniqueName)
+// See https://github.com/gazebosim/gz-fuel-tools/issues/231
+TEST(ModelIdentifier, IGN_UTILS_TEST_DISABLED_ON_WIN32(UniqueName))
 {
   ignition::fuel_tools::ServerConfig srv1;
   srv1.SetUrl(common::URI("https://localhost:8001/"));


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

Temporary remedy for #231. This is a continuation of the issue described in #106 IIUC.

## Summary
Disabled known to fail tests, in order to get CI green checks to clean the whole stack.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> Actually disables tests on windows
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

PR jobs should be green, except windows with protobuf warnings.