### PR TITLE
Remove unnecessarily added testing dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-common
-gz_find_package(gz-common5 REQUIRED PRIVATE COMPONENTS testing)
+gz_find_package(gz-common5 REQUIRED PRIVATE)
 set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 #--------------------------------------


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>

# 🦟 Bug fix

## Summary

@Blast545 noted that this additional dependency snuck in on #269.  It is related to some future work I have with using the testing module and not needed at this time.  This should resolve broken deb\builder jobs: https://build.osrfoundation.org/job/ign-fuel-tools8-debbuilder/420/

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
