### PR TITLE
Gz cache

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -10,6 +10,7 @@
   Additionally, they will only be available when including the corresponding `ignition/...` header.
   Use the `gz_` prefix instead.
   * `ign_strcat`, `ign_strcpy`, `ign_sprintf`, `ign_strdup`
+* The default cache location has moved from `~/.ignition/fuel` to `~/.gz/fuel`.
 
 ### Breaking Changes
 

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -41,7 +41,7 @@ class gz::fuel_tools::ClientConfigPrivate
             std::string homePath;
             gz::common::env(GZ_HOMEDIR, homePath);
             this->cacheLocation = common::joinPaths(
-                homePath, ".ignition", "fuel");
+                homePath, ".gz", "fuel");
 
             this->servers.push_back(ServerConfig());
           }

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -428,7 +428,7 @@ bool ClientConfig::LoadConfig(const std::string &_file)
   std::string homePath;
   gz::common::env(GZ_HOMEDIR, homePath);
   std::string cacheLocation = gz::common::joinPaths(
-    homePath, ".ignition", "fuel");
+    homePath, ".gz", "fuel");
 
   // The user wants to overwrite the default cache path.
   if (!cacheLocationConfig.empty())

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -102,7 +102,7 @@ TEST(ClientConfig, CustomDefaultConfiguration)
     config.Servers().front().Url().Str());
 
   std::string defaultCacheLocation = gz::common::joinPaths(
-    homePath(), ".ignition", "fuel");
+    homePath(), ".gz", "fuel");
   EXPECT_EQ(defaultCacheLocation, config.CacheLocation());
 }
 
@@ -309,9 +309,9 @@ TEST(ClientConfig, AsString)
     gzdbg << str << std::endl;
 
 #ifndef _WIN32
-    EXPECT_NE(str.find(".ignition/fuel"), std::string::npos);
+    EXPECT_NE(str.find(".gz/fuel"), std::string::npos);
 #else
-    EXPECT_NE(str.find(".ignition\\fuel"), std::string::npos);
+    EXPECT_NE(str.find(".gz\\fuel"), std::string::npos);
 #endif
     EXPECT_NE(str.find("https://fuel.ignitionrobotics.org"), std::string::npos);
   }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Moves the cache folder from `.ignition` to `.gz`.

## Test it
```
gz fuel download --url https://fuel.gazebosim.org/1.0/OpenRobotics/models/Warehouse
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.