### PR TITLE
Remove fuel.ignitionrobotics.org from ClientConfig

### DIFF
--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -44,13 +44,6 @@ class gz::fuel_tools::ClientConfigPrivate
                 homePath, ".gz", "fuel");
 
             this->servers.push_back(ServerConfig());
-
-            // Add in fuel.gazebosim.org as another default server config.
-            ServerConfig gzServerConfig;
-            gzServerConfig.SetUrl(
-                common::URI("https://fuel.ignitionrobotics.org"));
-            gzServerConfig.SetVersion("1.0");
-            this->servers.push_back(gzServerConfig);
           }
 
   /// \brief Clear values.

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -76,7 +76,7 @@ std::string cachePath()
 TEST(ClientConfig, InitiallyDefaultServers)
 {
   ClientConfig config;
-  EXPECT_EQ(2u, config.Servers().size());
+  EXPECT_EQ(1u, config.Servers().size());
 }
 
 /////////////////////////////////////////////////
@@ -88,7 +88,7 @@ TEST(ClientConfig, ServersCanBeAdded)
   srv.SetUrl(common::URI("http://asdf"));
   config.AddServer(srv);
 
-  ASSERT_EQ(3u, config.Servers().size());
+  ASSERT_EQ(2u, config.Servers().size());
   EXPECT_EQ(std::string("http://asdf"), config.Servers().back().Url().Str());
 }
 
@@ -97,11 +97,9 @@ TEST(ClientConfig, ServersCanBeAdded)
 TEST(ClientConfig, CustomDefaultConfiguration)
 {
   ClientConfig config;
-  ASSERT_EQ(2u, config.Servers().size());
+  ASSERT_EQ(1u, config.Servers().size());
   EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
-  EXPECT_EQ("https://fuel.ignitionrobotics.org",
-    config.Servers()[1].Url().Str());
 
   std::string defaultCacheLocation = gz::common::joinPaths(
     homePath(), ".gz", "fuel");
@@ -136,13 +134,11 @@ TEST(ClientConfig, CustomConfiguration)
 
   EXPECT_TRUE(config.LoadConfig(testPath));
 
-  ASSERT_EQ(4u, config.Servers().size());
+  ASSERT_EQ(3u, config.Servers().size());
   EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
-  EXPECT_EQ("https://fuel.ignitionrobotics.org",
-    config.Servers()[1].Url().Str());
   EXPECT_EQ("https://api.gazebosim.org",
-    config.Servers()[2].Url().Str());
+    config.Servers()[1].Url().Str());
   EXPECT_EQ("https://myserver",
     config.Servers().back().Url().Str());
 
@@ -166,10 +162,10 @@ TEST(ClientConfig, RepeatedServerConfiguration)
       << "# The list of servers."                 << std::endl
       << "servers:"                               << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"    << std::endl
       << ""                                       << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"    << std::endl
       << ""                                       << std::endl
       << "# Where are the assets stored in disk." << std::endl
       << "cache:"                                 << std::endl
@@ -317,7 +313,7 @@ TEST(ClientConfig, AsString)
 #else
     EXPECT_NE(str.find(".gz\\fuel"), std::string::npos);
 #endif
-    EXPECT_NE(str.find("https://fuel.ignitionrobotics.org"), std::string::npos);
+    EXPECT_NE(str.find("https://fuel.gazebosim.org"), std::string::npos);
   }
 
   {

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -164,10 +164,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/1.0/german/models/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/german/models/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseModelUrl(gz::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -184,10 +184,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/5.0/german/models/Cardboard Box/6/"};
+      "https://fuel.gazebosim.org/5.0/german/models/Cardboard Box/6/"};
     EXPECT_TRUE(client.ParseModelUrl(gz::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -201,10 +201,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box"};
     EXPECT_TRUE(client.ParseModelUrl(gz::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -220,10 +220,10 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/tip"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box/tip"};
     EXPECT_TRUE(client.ParseModelUrl(gz::common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -255,28 +255,28 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/german/models/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseModelUrl(gz::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/banana/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/german/models/Cardboard Box"};
     EXPECT_FALSE(client.ParseModelUrl(gz::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/99/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/german/models/Cardboard Box"};
     EXPECT_FALSE(client.ParseModelUrl(gz::common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/2/2/german/models"
+      "https://fuel.gazebosim.org/2/2/german/models"
         "/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseModelUrl(gz::common::URI(url), id));
   }
@@ -291,11 +291,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/models/"
         "Cordless Drill/tip/files/meshes/cordless_drill.dae"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "cordless drill");
@@ -310,11 +310,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -329,11 +329,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/5.0/OpenRobotics/models/Pine Tree/tip/"
       "files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -346,11 +346,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/models/pine tree/tip/"
+      "https://fuel.gazebosim.org/OpenRobotics/models/pine tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "openrobotics");
@@ -366,11 +366,11 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/openrobotics/models/Pine Tree/tip/"
+      "https://fuel.gazebosim.org/openrobotics/models/Pine Tree/tip/"
       "files/materials/scripts/pine_tree.material"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "pine tree");
@@ -416,7 +416,7 @@ TEST_F(FuelClientTest, DownloadModel)
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"};
+        "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -432,7 +432,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
+        "fuel.gazebosim.org", "chapulina", "models", "test box");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -454,7 +454,7 @@ TEST_F(FuelClientTest, DownloadModel)
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/iche033/models/Rescue Randy"};
+        "https://fuel.gazebosim.org/1.0/iche033/models/Rescue Randy"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -470,7 +470,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "iche033", "models", "rescue randy");
+        "fuel.gazebosim.org", "iche033", "models", "rescue randy");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -507,9 +507,9 @@ TEST_F(FuelClientTest, DownloadModel)
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/nate/models/hatchback_red_1"};
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/nate/models/hatchback_1"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -579,7 +579,7 @@ TEST_F(FuelClientTest, DownloadModel)
   // Try using nonexistent URL
   {
     std::string url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/"
+        "https://fuel.gazebosim.org/1.0/chapulina/models/"
           "Inexistent model"};
     std::string path;
     Result result = client.DownloadModel(common::URI(url), path);
@@ -616,9 +616,9 @@ TEST_F(FuelClientTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_red_1"};
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/JShep1/models/hatchback_1"};
 
     ModelIdentifier id;
     ModelIdentifier depId;
@@ -814,10 +814,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/1.0/german/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -833,10 +833,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/german/worlds/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -852,10 +852,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/5.0/german/worlds/Cardboard Box/6"};
+      "https://fuel.gazebosim.org/5.0/german/worlds/Cardboard Box/6"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -869,10 +869,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "german");
@@ -890,10 +890,10 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/tip/"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box/tip/"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "german");
     EXPECT_EQ(id.Name(), "cardboard box");
@@ -922,28 +922,28 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/german/worlds/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/banana/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/german/worlds/Cardboard Box"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/99/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/german/worlds/Cardboard Box"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/2/2/german/worlds/Cardboard Box"
+      "https://fuel.gazebosim.org/2/2/german/worlds/Cardboard Box"
         "/banana"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
@@ -958,11 +958,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -977,11 +977,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty sky");
@@ -996,11 +996,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/5.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1013,11 +1013,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "openrobotics");
@@ -1033,11 +1033,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1075,7 +1075,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
   ServerConfig server;
   server.SetUrl(gz::common::URI(
-        "https://fuel.ignitionrobotics.org"));
+        "https://fuel.gazebosim.org"));
 
   ClientConfig config;
   config.AddServer(server);
@@ -1088,7 +1088,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Download world from URL
   {
     // Unversioned URL should get the latest available version
-    common::URI url{"https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+    common::URI url{"https://fuel.gazebosim.org/1.0/OpenRobotics/"
                     "worlds/Test world"};
 
     // Check it is not cached
@@ -1105,7 +1105,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
     // Check it was downloaded to `1`
     auto worldPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world");
+        "fuel.gazebosim.org", "openrobotics", "worlds", "test world");
 
     EXPECT_EQ(path, common::joinPaths(worldPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(worldPath, "2")));
@@ -1124,7 +1124,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Try using nonexistent URL
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Bad world"};
+        "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Bad world"};
     std::string path;
     auto result = client.DownloadWorld(url, path);
     EXPECT_FALSE(result);
@@ -1353,7 +1353,7 @@ TEST_F(FuelClientTest, Models)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     ModelIter iter = client.Models(serverConfig);
     EXPECT_TRUE(iter);
   }
@@ -1387,7 +1387,7 @@ TEST_F(FuelClientTest, Worlds)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     WorldIter iter = client.Worlds(serverConfig);
     EXPECT_TRUE(iter);
   }

--- a/src/Interface_TEST.cc
+++ b/src/Interface_TEST.cc
@@ -60,7 +60,7 @@ TEST(Interface, FetchResources)
   {
     // Check it's not cached
     common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"};
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"};
     {
       Result res = client.CachedModel(modelUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
@@ -72,25 +72,25 @@ TEST(Interface, FetchResources)
 
     std::string sdfPath = sdfFromPath(path);
     EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2",
+      "fuel.gazebosim.org", "chapulina", "models", "test box", "2",
       "model.sdf"), sdfPath);
 
     // Check it was downloaded to `2`
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"));
+      "fuel.gazebosim.org", "chapulina", "models", "test box", "2"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2", "model.sdf")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "test box", "2", "model.config")));
 
     // Check it wasn't downloaded to model root directory
     EXPECT_FALSE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "models", "Test box", "model.config")));
 
     // Check it is cached
@@ -99,7 +99,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "test box", "2"),
+        "fuel.gazebosim.org", "chapulina", "models", "test box", "2"),
         cachedPath);
      }
   }
@@ -108,9 +108,9 @@ TEST(Interface, FetchResources)
   {
     // Check neither file nor its model are cached
     common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Bus/1/"};
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Bus/1/"};
     common::URI modelFileUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Bus/1/files"
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/Bus/1/files"
       "/meshes/bus.obj"};
 
     {
@@ -129,25 +129,25 @@ TEST(Interface, FetchResources)
 
     // Check entire model was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1")));
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "models", "bus",
+      "fuel.gazebosim.org", "openrobotics", "models", "bus",
       "1", "meshes", "bus.obj"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
         "openrobotics", "models", "bus", "1", "model.sdf")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "model.config")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "meshes/bus.obj")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "meshes/bus.mtl")));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "openrobotics", "models", "bus", "1", "materials", "textures",
           "bus.png")));
 
@@ -157,14 +157,14 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1"),
+        "fuel.gazebosim.org", "openrobotics", "models", "bus", "1"),
         cachedPath);
     }
 
     {
       std::string sdfFile = sdfFromPath(cachedPath);
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-            "fuel.ignitionrobotics.org", "openrobotics", "models", "bus",
+            "fuel.gazebosim.org", "openrobotics", "models", "bus",
             "1", "model.sdf"), sdfFile);
     }
 
@@ -174,7 +174,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "models", "bus", "1",
+        "fuel.gazebosim.org", "openrobotics", "models", "bus", "1",
         "meshes", "bus.obj"), cachedPath);
      }
   }
@@ -183,7 +183,7 @@ TEST(Interface, FetchResources)
   {
     // Check it's not cached
     common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/worlds/Test world"};
+      "https://fuel.gazebosim.org/1.0/openrobotics/worlds/Test world"};
     {
       Result res = client.CachedWorld(worldUrl, cachedPath);
       EXPECT_FALSE(res) << "Cached Path: " << cachedPath;
@@ -197,13 +197,13 @@ TEST(Interface, FetchResources)
 
     // Check it was downloaded to `1`
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds",
+      "fuel.gazebosim.org", "openrobotics", "worlds",
       "test world", "2"));
     EXPECT_TRUE(common::exists(common::joinPaths("test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world",
+      "fuel.gazebosim.org", "openrobotics", "worlds", "test world",
       "2")));
     EXPECT_TRUE(common::exists(common::joinPaths("test_cache",
-      "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world", "2",
+      "fuel.gazebosim.org", "openrobotics", "worlds", "test world", "2",
       "test.world")));
 
     // Check it is cached
@@ -212,7 +212,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world",
+        "fuel.gazebosim.org", "openrobotics", "worlds", "test world",
         "2"), cachedPath);
      }
   }
@@ -221,9 +221,9 @@ TEST(Interface, FetchResources)
   {
     // Check neither file nor its world are cached
     common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"};
+      "https://fuel.gazebosim.org/1.0/chapulina/worlds/Test world/2/"};
     common::URI worldFileUrl{
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/worlds/Test world/2/"
+      "https://fuel.gazebosim.org/1.0/chapulina/worlds/Test world/2/"
       "files/thumbnails/1.png"};
 
     {
@@ -242,13 +242,13 @@ TEST(Interface, FetchResources)
 
     // Check entire world was downloaded to `1`
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "worlds", "test world", "2")));
     EXPECT_EQ(path, common::joinPaths(common::cwd(), "test_cache",
-      "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2",
+      "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2",
       "thumbnails", "1.png"));
     EXPECT_TRUE(common::exists(
-        common::joinPaths("test_cache", "fuel.ignitionrobotics.org",
+        common::joinPaths("test_cache", "fuel.gazebosim.org",
           "chapulina", "worlds", "test world", "2", "test.world")));
 
     // Check world is cached
@@ -257,14 +257,14 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2"),
+        "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2"),
         cachedPath);
     }
 
     {
       std::string sdfFile = sdfFromPath(cachedPath);
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-            "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world",
+            "fuel.gazebosim.org", "chapulina", "worlds", "test world",
             "2", "test.sdf"), sdfFile);
     }
 
@@ -274,7 +274,7 @@ TEST(Interface, FetchResources)
       EXPECT_TRUE(res);
       EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res.Type());
       EXPECT_EQ(common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "worlds", "test world", "2",
+        "fuel.gazebosim.org", "chapulina", "worlds", "test world", "2",
         "thumbnails", "1.png"), cachedPath);
      }
   }

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -101,7 +101,7 @@ TEST(CmdLine,
     GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListConfigServerUgly))
 {
   auto output = custom_exec_str(g_listCmd + " -t model --raw");
-  EXPECT_NE(output.find("https://fuel.ignitionrobotics.org/1.0/"),
+  EXPECT_NE(output.find("https://fuel.gazebosim.org/1.0/"),
             std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;
 }
@@ -113,16 +113,16 @@ TEST(CmdLine,
     DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(ModelListCustomServerPretty))
 {
   auto output = custom_exec_str(
-      g_listCmd + " -t model -u https://staging-fuel.ignitionrobotics.org");
+      g_listCmd + " -t model -u https://staging-fuel.gazebosim.org");
 
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_NE(output.find("owners"), std::string::npos) << output;
   EXPECT_NE(output.find("models"), std::string::npos) << output;
 
-  EXPECT_EQ(output.find("https://fuel.ignitionrobotics.org"), std::string::npos)
+  EXPECT_EQ(output.find("https://fuel.gazebosim.org"), std::string::npos)
       << output;
-  EXPECT_EQ(output.find("https://staging-fuel.ignitionrobotics.org/1.0/"),
+  EXPECT_EQ(output.find("https://staging-fuel.gazebosim.org/1.0/"),
       std::string::npos) << output;
 }
 
@@ -131,8 +131,8 @@ TEST(CmdLine,
 TEST(CmdLine, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WorldListConfigServerUgly))
 {
   auto output = custom_exec_str(g_listCmd +
-      " -t world --raw -u https://staging-fuel.ignitionrobotics.org");
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+      " -t world --raw -u https://staging-fuel.gazebosim.org");
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;
 }
@@ -144,9 +144,9 @@ TEST(CmdLine,
     DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(WorldListCustomServerPretty))
 {
   auto output = custom_exec_str(
-      g_listCmd + " -t world -u https://staging-fuel.ignitionrobotics.org");
+      g_listCmd + " -t world -u https://staging-fuel.gazebosim.org");
 
-  EXPECT_NE(output.find("https://staging-fuel.ignitionrobotics.org"),
+  EXPECT_NE(output.find("https://staging-fuel.gazebosim.org"),
       std::string::npos) << output;
   EXPECT_NE(output.find("owners"), std::string::npos) << output;
   EXPECT_NE(output.find("worlds"), std::string::npos) << output;

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -95,7 +95,7 @@ TEST_F(CmdLine, ModelListConfigServerUgly)
 {
   EXPECT_TRUE(listModels("", "", "true"));
 
-  EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -108,20 +108,20 @@ TEST_F(CmdLine, ModelListConfigServerUgly)
 TEST_F(CmdLine,
        DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(ModelListConfigServerPretty))
 {
-  EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org"));
+  EXPECT_TRUE(listModels("https://staging-fuel.gazebosim.org"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("models"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -132,11 +132,11 @@ TEST_F(CmdLine,
 TEST_F(CmdLine,
        DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(ModelListConfigServerPrettyOwner))
 {
-  EXPECT_TRUE(listModels("https://staging-fuel.ignitionrobotics.org",
+  EXPECT_TRUE(listModels("https://staging-fuel.gazebosim.org",
       "openrobotics"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("1 owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -147,10 +147,10 @@ TEST_F(CmdLine,
   EXPECT_EQ(this->stdOutBuffer.str().find("20 models"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -182,7 +182,7 @@ TEST_F(CmdLine, ModelDownloadUnversioned)
 {
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"));
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box"));
 
   // Check output
   EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
@@ -191,13 +191,13 @@ TEST_F(CmdLine, ModelDownloadUnversioned)
 
   // Check files
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "chapulina", "models", "test box", "2", "model.sdf")));
 }
 
@@ -216,7 +216,7 @@ TEST_F(CmdLine, DownloadConfigCache)
   ofs << "---"                                    << std::endl
       << "servers:"                               << std::endl
       << "  -"                                    << std::endl
-      << "    url: https://fuel.ignitionrobotics.org"  << std::endl
+      << "    url: https://fuel.gazebosim.org"  << std::endl
       << ""                                       << std::endl
       << "cache:"                                 << std::endl
       << "  path: " << this->testCachePath << std::endl
@@ -226,7 +226,7 @@ TEST_F(CmdLine, DownloadConfigCache)
 
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box",
+      "https://fuel.gazebosim.org/1.0/chapulina/models/Test box",
       testPath.c_str()));
 
   // Check output
@@ -236,7 +236,7 @@ TEST_F(CmdLine, DownloadConfigCache)
 
   // Check files
   auto modelPath = common::joinPaths(this->testCachePath,
-      "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
+      "fuel.gazebosim.org", "chapulina", "models", "test box");
   EXPECT_TRUE(common::isDirectory(modelPath));
   EXPECT_TRUE(common::isDirectory(common::joinPaths(modelPath, "2")));
   EXPECT_TRUE(common::isFile(common::joinPaths(modelPath, "2",
@@ -261,10 +261,10 @@ TEST_F(CmdLine,
        DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(WorldListConfigServerUgly))
 {
   EXPECT_TRUE(listWorlds(
-        "https://staging-fuel.ignitionrobotics.org", "", "true"));
+        "https://staging-fuel.gazebosim.org", "", "true"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"),
+        "https://staging-fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -277,31 +277,31 @@ TEST_F(CmdLine,
 TEST_F(CmdLine,
        DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(WorldListConfigServerPretty))
 {
-  EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org"));
+  EXPECT_TRUE(listWorlds("https://staging-fuel.gazebosim.org"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
+        "https://staging-fuel.gazebosim.org"), std::string::npos)
     << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("owners"), std::string::npos)
       << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
 /////////////////////////////////////////////////
 TEST_F(CmdLine, WorldListCustomServerPrettyOwner)
 {
-  EXPECT_TRUE(listWorlds("https://staging-fuel.ignitionrobotics.org",
+  EXPECT_TRUE(listWorlds("https://staging-fuel.gazebosim.org",
       "openrobotics"));
 
   EXPECT_NE(this->stdOutBuffer.str().find(
-        "https://staging-fuel.ignitionrobotics.org"), std::string::npos)
+        "https://staging-fuel.gazebosim.org"), std::string::npos)
     << this->stdOutBuffer.str();
   EXPECT_NE(this->stdOutBuffer.str().find("worlds"), std::string::npos)
       << this->stdOutBuffer.str();
@@ -310,10 +310,10 @@ TEST_F(CmdLine, WorldListCustomServerPrettyOwner)
   EXPECT_EQ(this->stdOutBuffer.str().find("20 worlds"), std::string::npos)
       << this->stdOutBuffer.str();
 
-  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.ignitionrobotics.org"),
+  EXPECT_EQ(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();
   EXPECT_EQ(this->stdOutBuffer.str().find(
-      "https://staging-fuel.ignitionrobotics.org/1.0/"), std::string::npos)
+      "https://staging-fuel.gazebosim.org/1.0/"), std::string::npos)
       << this->stdOutBuffer.str();
 }
 
@@ -347,7 +347,7 @@ TEST_F(CmdLine, WorldDownloadUnversioned)
 {
   // Download
   EXPECT_TRUE(downloadUrl(
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Test world"));
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Test world"));
 
   // Check output
   EXPECT_NE(this->stdOutBuffer.str().find("Download succeeded"),
@@ -356,13 +356,13 @@ TEST_F(CmdLine, WorldDownloadUnversioned)
 
   // Check files
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 }
 
@@ -381,7 +381,7 @@ TEST_P(DownloadCollectionTest, AllItems)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, nullptr, GetParam()));
 
@@ -393,46 +393,46 @@ TEST_P(DownloadCollectionTest, AllItems)
   // Check files
   // Model: Backpack
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
      "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
 }
 
@@ -444,7 +444,7 @@ TEST_P(DownloadCollectionTest, Models)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, "model", GetParam()));
 
@@ -456,34 +456,34 @@ TEST_P(DownloadCollectionTest, Models)
   // Check files
   // Model: Backpack
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack", "2", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase", "2", "model.sdf")));
 
   // World: Test World
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
 
   // World: Test World 2
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world2")));
 }
 
@@ -495,7 +495,7 @@ TEST_P(DownloadCollectionTest, Worlds)
 {
   // Download
   EXPECT_TRUE(
-      downloadUrl("https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+      downloadUrl("https://fuel.gazebosim.org/1.0/OpenRobotics/"
                   "collections/TestCollection",
                   nullptr, nullptr, "world", GetParam()));
 
@@ -507,33 +507,33 @@ TEST_P(DownloadCollectionTest, Worlds)
   // Check files
   // Model: Backpack
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "backpack")));
 
   // Model: TEAMBASE
   EXPECT_FALSE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "models", "teambase")));
 
   // World: Test World
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world", "2", "test.world")));
 
   // World: Test World 2
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2")));
   EXPECT_TRUE(common::isDirectory(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2")));
   EXPECT_TRUE(common::isFile(
-    common::joinPaths(this->testCachePath, "fuel.ignitionrobotics.org",
+    common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
       "openrobotics", "worlds", "test world 2", "2", "test.world")));
 }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Removes `fuel.ignitionrobotics.org` from ClientConfig. This will leave `fuel.gazebosim.org`.

## Test it
Run the tests.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.