### PR TITLE
Fixed configuration tutorial links

### DIFF
--- a/tutorials/02_configuration.md
+++ b/tutorials/02_configuration.md
@@ -48,7 +48,7 @@ Create a file `/tmp/my_config.yaml` with the following content:
 # The list of servers.
 servers:
   -
-    url: https://fuel.ignitionrobotics.org
+    url: https://fuel.gazebosim.org
 
 # Where are the assets stored in disk.
 cache:
@@ -66,26 +66,26 @@ Download the file `download.cc` and save it under `/tmp/conf_tutorial`:
 
 ```bash
 # Ubuntu and MacOS
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc
 
 # Windows
 ## CMD
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc -o download.cc
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc -o download.cc
 ## PowerShell
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc -o download.cc
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc -o download.cc
 ```
 
 Also, download `CMakeLists.txt` for compiling the example:
 
 ```bash
 # Ubuntu and MacOS
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt
 
 # Windows
 ## CMD
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt -o CMakeLists.txt
 ## PowerShell
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt -o CMakeLists.txt
 ```
 
 Install the gflags dependency:
@@ -122,7 +122,7 @@ And now the fun part, execute it:
 ```
 
 Verify that you have the model in
-`/tmp/gz/fuel/fuel.ignitionrobotics.org/caguero/models/Beer`,
+`/tmp/gz/fuel/fuel.gazebosim.org/caguero/models/beer`,
 as you configured in your YAML file.
 
 ## Walkthrough


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Fixed configuration tutorial links and some other tweaks. Related with https://github.com/gazebosim/garden-tutorial-party/issues/2068

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
