### PR TITLE
Fixed cpp api tutorial links

### DIFF
--- a/tutorials/04_cpp_api.md
+++ b/tutorials/04_cpp_api.md
@@ -18,22 +18,22 @@ Download the files `list.cc`, `details.cc`, `download.cc`,
 
 ```bash
 # Ubuntu or MacOS
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/list.cc
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/details.cc
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc
-wget https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/list.cc
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/details.cc
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc
+wget https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt
 
 # Windows
 ## CMD
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/list.cc -o list.cc
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/details.cc -o details.cc
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc -o download.cc
-curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/list.cc -o list.cc
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/details.cc -o details.cc
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc -o download.cc
+curl -sk https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt -o CMakeLists.txt
 ## PowerShell
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/list.cc -o list.cc
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/details.cc -o details.cc
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/download.cc -o download.cc
-curl https://github.com/gazebosim/gz-fuel-tools/raw/main/example/CMakeLists.txt -o CMakeLists.txt
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/list.cc -o list.cc
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/details.cc -o details.cc
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/download.cc -o download.cc
+curl https://github.com/gazebosim/gz-fuel-tools/raw/gz-fuel-tools8/example/CMakeLists.txt -o CMakeLists.txt
 ```
 
 Let's start by compiling the examples:


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

Fixed cpp api tutorial links. https://github.com/gazebosim/garden-tutorial-party/issues/2050

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
