### PR TITLE
Clean up a few Windows warnings

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 project(fuel-tools-examples)
 
 # Find the Gazebo Fuel Tools library
-find_package(gz-fuel_tools9 QUIET REQUIRED)
-set(GZ_FUEL_TOOLS_VER ${gz-fuel_tools9_VERSION_MAJOR})
+find_package(gz-fuel_tools8 QUIET REQUIRED)
+set(GZ_FUEL_TOOLS_VER ${gz-fuel_tools8_VERSION_MAJOR})
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GZ-FUEL-TOOLS_CXX_FLAGS}")
 

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -15,12 +15,12 @@
  *
 */
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)  // foo needs to have dll-interface
 #endif
 #include <google/protobuf/text_format.h>
-#include <gz/msgs/fuel_metadata.pb.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
@@ -36,6 +36,7 @@
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Util.hh>
 
+#include <gz/msgs/fuel_metadata.pb.h>
 #include <gz/msgs/Utility.hh>
 
 #include "gz/fuel_tools/ClientConfig.hh"

--- a/src/Interface.cc
+++ b/src/Interface.cc
@@ -15,14 +15,16 @@
  *
 */
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)  // foo needs to have dll-interface
 #endif
 #include <google/protobuf/text_format.h>
-#include <gz/msgs/fuel_metadata.pb.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+
+#include <gz/msgs/fuel_metadata.pb.h>
 
 #include <gz/msgs/Utility.hh>
 #include "gz/common/Console.hh"

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -19,25 +19,20 @@
 #include <string.h>
 #include <tinyxml2.h>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)  // foo needs to have dll-interface
 #endif
 #include <google/protobuf/text_format.h>
-#include <gz/msgs/fuel_metadata.pb.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
 #include <csignal>
 #include <exception>
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#endif
+#include <gz/msgs/fuel_metadata.pb.h>
 #include <gz/msgs/Utility.hh>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #ifdef _WIN32
 // DELETE is defined in winnt.h and causes a problem with REST::DELETE


### PR DESCRIPTION
# 🦟 Bug fix

Related to: https://github.com/gazebosim/gz-sim/pull/1771

## Summary

Remove some Windows warnings.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.