### PR TITLE
Fix build when JSON_USE_EXCEPTION == 0

### DIFF
--- a/src/JSONParser.cc
+++ b/src/JSONParser.cc
@@ -78,7 +78,8 @@ bool ParseLicenseImpl(const Json::Value &_json,
     if (_json.isMember("ID"))
       _license.second = _json["ID"].asUInt();
   }
-#if JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10
+#if ((JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10) || \
+     JSON_USE_EXCEPTION == 0)
   catch (...)
   {
     std::string what;
@@ -109,7 +110,8 @@ std::vector<std::string> JSONParser::ParseTags(const Json::Value &_json)
     for (auto tagIt = _json.begin(); tagIt != _json.end(); ++tagIt)
       tags.push_back(tagIt->asString());
   }
-#if JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10
+#if ((JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10) || \
+     JSON_USE_EXCEPTION == 0)
   catch (...)
   {
     std::string what;
@@ -221,7 +223,8 @@ bool JSONParser::ParseModelImpl(
     if (_json.isMember("version"))
       _model.SetVersion(_json["version"].asUInt());
   }
-#if JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10
+#if ((JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10) || \
+     JSON_USE_EXCEPTION == 0)
   catch (...)
   {
     std::string what;
@@ -326,7 +329,8 @@ bool JSONParser::ParseWorldImpl(
     if (_json.isMember("version"))
       _world.SetVersion(_json["version"].asUInt());
   }
-#if JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10
+#if ((JSONCPP_VERSION_MAJOR < 1 && JSONCPP_VERSION_MINOR < 10) || \
+     JSON_USE_EXCEPTION == 0)
   catch (...)
   {
     std::string what;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Newer versions of jsoncpp do not provide exception classes when JSON_USE_EXCEPTION is off.

Updating the #if directives in JSONParse.cc allows this file to compile against jsoncpp configured to not throw.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
