### PR TITLE
Reduce asset download sizes in Fuel_Client_TEST

### DIFF
--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -145,12 +145,12 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://some.example.org/1.0/german/models/Cardboard Box"};
+      "https://some.example.org/1.0/openroboticstest/models/Cardboard Box"};
     EXPECT_TRUE(client.ParseModelUrl(common::URI(url), id));
 
     EXPECT_EQ(id.Server().Url().Str(), "https://some.example.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -164,12 +164,12 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/1.0/german/models/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/openroboticstest/models/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseModelUrl(common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 4u);
   }
@@ -183,12 +183,13 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/5.0/german/models/Cardboard Box/6"};
+      "https://fuel.gazebosim.org/5.0/openroboticstest/models/Cardboard Box/6/"
+    };
     EXPECT_TRUE(client.ParseModelUrl(common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 6u);
   }
@@ -200,12 +201,12 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/openroboticstest/models/Cardboard Box"};
     EXPECT_TRUE(client.ParseModelUrl(common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -219,12 +220,12 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client(config);
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/tip"};
+      "https://fuel.gazebosim.org/openroboticstest/models/Cardboard Box/tip"};
     EXPECT_TRUE(client.ParseModelUrl(common::URI(url), id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -254,28 +255,30 @@ TEST_F(FuelClientTest, ParseModelURL)
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/german/models/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/openroboticstest/models/Cardboard Box/banana"
+    };
     EXPECT_FALSE(client.ParseModelUrl(common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/banana/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/openroboticstest/models/Cardboard Box"
+    };
     EXPECT_FALSE(client.ParseModelUrl(common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/99/german/models/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/openroboticstest/models/Cardboard Box"};
     EXPECT_FALSE(client.ParseModelUrl(common::URI(url), id));
   }
   {
     FuelClient client;
     ModelIdentifier id;
     const std::string url{
-      "https://fuel.ignitionrobotics.org/2/2/german/models"
+      "https://fuel.gazebosim.org/2/2/openroboticstest/models"
         "/Cardboard Box/banana"};
     EXPECT_FALSE(client.ParseModelUrl(common::URI(url), id));
   }
@@ -290,15 +293,15 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/"
-        "Cordless Drill/tip/files/meshes/cordless_drill.dae"};
+      "https://fuel.gazebosim.org/1.0/openroboticstest/models/"
+        "backpack/tip/files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "openrobotics");
-    EXPECT_EQ(id.Name(), "cordless drill");
-    EXPECT_EQ(filePath, "meshes/cordless_drill.dae");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
+    EXPECT_EQ(id.Name(), "backpack");
+    EXPECT_EQ(filePath, "model.sdf");
   }
 
   // URL - with client config
@@ -309,15 +312,15 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/Pine Tree/tip/"
-      "files/materials/scripts/pine_tree.material"};
+      "https://fuel.gazebosim.org/1.0/openroboticstest/models/backpack/"
+        "tip/files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "openrobotics");
-    EXPECT_EQ(id.Name(), "pine tree");
-    EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
+    EXPECT_EQ(id.Name(), "backpack");
+    EXPECT_EQ(filePath, "model.sdf");
   }
 
   // URL - version different from config
@@ -328,14 +331,14 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/models/Pine Tree/tip/"
-      "files/model.sdf"};
+      "https://fuel.gazebosim.org/5.0/openroboticstest/models/backpack/"
+        "tip/files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "openrobotics");
-    EXPECT_EQ(id.Name(), "pine tree");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
+    EXPECT_EQ(id.Name(), "backpack");
     EXPECT_EQ(filePath, "model.sdf");
   }
 
@@ -345,16 +348,16 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/models/pine tree/tip/"
-      "files/materials/scripts/pine_tree.material"};
+      "https://fuel.gazebosim.org/openroboticstest/models/backpack/tip/"
+      "files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
-    EXPECT_EQ(id.Owner(), "openrobotics");
-    EXPECT_EQ(id.Name(), "pine tree");
-    EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
+    EXPECT_EQ(id.Name(), "backpack");
+    EXPECT_EQ(filePath, "model.sdf");
   }
 
   // Unique name - with client config
@@ -365,15 +368,15 @@ TEST_F(FuelClientTest, ParseModelFileURL)
     ModelIdentifier id;
     std::string filePath;
     const common::URI modelUrl{
-      "https://fuel.ignitionrobotics.org/openrobotics/models/Pine Tree/tip/"
-      "files/materials/scripts/pine_tree.material"};
+      "https://fuel.gazebosim.org/openroboticstest/models/backpack/tip/"
+      "files/model.sdf"};
     EXPECT_TRUE(client.ParseModelFileUrl(modelUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "openrobotics");
-    EXPECT_EQ(id.Name(), "pine tree");
-    EXPECT_EQ(filePath, "materials/scripts/pine_tree.material");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
+    EXPECT_EQ(id.Name(), "backpack");
+    EXPECT_EQ(filePath, "model.sdf");
   }
 
   // Bad URL
@@ -397,7 +400,7 @@ TEST_F(FuelClientTest, ParseModelFileURL)
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
+// https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(FuelClientTest, DownloadModel)
 {
   // Configure to use binary path as cache
@@ -415,7 +418,7 @@ TEST_F(FuelClientTest, DownloadModel)
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/Test box"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/test box"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -431,12 +434,12 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "chapulina", "models", "test box");
+        "fuel.gazebosim.org", "openroboticstest", "models", "test box");
 
-    EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
-    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
-    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2", "model.sdf")));
-    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2",
+    EXPECT_EQ(path, common::joinPaths(modelPath, "1"));
+    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "1")));
+    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "1", "model.sdf")));
+    EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "1",
         "model.config")));
 
     // Check it wasn't downloaded to model root directory
@@ -446,14 +449,14 @@ TEST_F(FuelClientTest, DownloadModel)
     Result res3 = client.CachedModel(url, cachedPath);
     EXPECT_TRUE(res3);
     EXPECT_EQ(ResultType::FETCH_ALREADY_EXISTS, res3.Type());
-    EXPECT_EQ(common::joinPaths(modelPath, "2"), cachedPath);
+    EXPECT_EQ(common::joinPaths(modelPath, "1"), cachedPath);
   }
 
   // Download model with pbr paths from URL and check that paths are fixed
   {
     // Unversioned URL should get the latest available version
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/iche033/models/Rescue Randy"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/Rescue Randy"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -469,7 +472,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
     // Check it was downloaded to `2`
     auto modelPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "iche033", "models", "rescue randy");
+        "fuel.gazebosim.org", "openroboticstest", "models", "rescue randy");
 
     EXPECT_EQ(path, common::joinPaths(modelPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(modelPath, "2")));
@@ -506,9 +509,10 @@ TEST_F(FuelClientTest, DownloadModel)
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/hatchback_red_1"
+    };
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/hatchback_1"};
 
     // Check it is not cached
     std::string cachedPath;
@@ -542,7 +546,7 @@ TEST_F(FuelClientTest, DownloadModel)
   // The dependency points to fuel.gazebosim.org.
   {
     common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/hatchback red"
+      "https://fuel.gazebosim.org/1.0/openrobotics/models/hatchback red"
     };
     common::URI depUrl{
       "https://fuel.gazebosim.org/1.0/openrobotics/models/hatchback"};
@@ -578,7 +582,7 @@ TEST_F(FuelClientTest, DownloadModel)
   // Try using nonexistent URL
   {
     std::string url{
-        "https://fuel.ignitionrobotics.org/1.0/chapulina/models/"
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/"
           "Inexistent model"};
     std::string path;
     Result result = client.DownloadModel(common::URI(url), path);
@@ -598,7 +602,7 @@ TEST_F(FuelClientTest, DownloadModel)
 
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
+// https://github.com/gazebosim/gz-fuel-tools/issues/106
 TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
 {
   // Configure to use binary path as cache
@@ -615,9 +619,10 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
   // Download model with a dependency specified within its `metadata.pbtxt`
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_red_1"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/hatchback_red_1"
+    };
     common::URI depUrl{
-        "https://fuel.ignitionrobotics.org/1.0/JShep1/models/hatchback_1"};
+        "https://fuel.gazebosim.org/1.0/openroboticstest/models/hatchback_1"};
 
     ModelIdentifier id;
     ModelIdentifier depId;
@@ -672,7 +677,7 @@ TEST_F(FuelClientTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelDependencies))
 
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
+// https://github.com/gazebosim/gz-fuel-tools/issues/106
 TEST_F(FuelClientTest, CachedModel)
 {
   // Configure to use binary path as cache and populate it
@@ -812,12 +817,12 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/1.0/openroboticstest/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -831,12 +836,12 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/1.0/german/worlds/Cardboard Box/4"};
+      "https://fuel.gazebosim.org/1.0/openroboticstest/worlds/Cardboard Box/4"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 4u);
   }
@@ -850,12 +855,12 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/5.0/german/worlds/Cardboard Box/6"};
+      "https://fuel.gazebosim.org/5.0/openroboticstest/worlds/Cardboard Box/6"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 6u);
   }
@@ -867,13 +872,13 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/openroboticstest/worlds/Cardboard Box"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -888,12 +893,12 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client(config);
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/tip/"};
+      "https://fuel.gazebosim.org/openroboticstest/worlds/Cardboard Box/tip/"};
     EXPECT_TRUE(client.ParseWorldUrl(url, id));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
-    EXPECT_EQ(id.Owner(), "german");
+    EXPECT_EQ(id.Owner(), "openroboticstest");
     EXPECT_EQ(id.Name(), "cardboard box");
     EXPECT_EQ(id.Version(), 0u);
   }
@@ -920,28 +925,29 @@ TEST_F(FuelClientTest, ParseWorldUrl)
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/german/worlds/Cardboard Box/banana"};
+      "https://fuel.gazebosim.org/openroboticstest/worlds/Cardboard Box/here"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/banana/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/banana/openroboticstest/worlds/Cardboard Box"
+    };
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/99/german/worlds/Cardboard Box"};
+      "https://fuel.gazebosim.org/99/openroboticstest/worlds/Cardboard Box"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
   {
     FuelClient client;
     WorldIdentifier id;
     const common::URI url{
-      "https://fuel.ignitionrobotics.org/2/2/german/worlds/Cardboard Box"
+      "https://fuel.gazebosim.org/2/2/openroboticstest/worlds/Cardboard Box"
         "/banana"};
     EXPECT_FALSE(client.ParseWorldUrl(url, id));
   }
@@ -956,11 +962,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -975,11 +981,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty sky");
@@ -994,11 +1000,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/5.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/5.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1011,11 +1017,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/OpenRobotics/worlds/Empty sky/tip/"
+      "https://fuel.gazebosim.org/OpenRobotics/worlds/Empty sky/tip/"
       "files/empty_sky.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_FALSE(id.Server().Version().empty());
     EXPECT_EQ("1.0", id.Server().Version());
     EXPECT_EQ(id.Owner(), "openrobotics");
@@ -1031,11 +1037,11 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
     WorldIdentifier id;
     std::string filePath;
     const common::URI worldUrl{
-      "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Empty/tip/"
+      "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Empty/tip/"
       "files/test.world"};
     EXPECT_TRUE(client.ParseWorldFileUrl(worldUrl, id, filePath));
 
-    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.ignitionrobotics.org");
+    EXPECT_EQ(id.Server().Url().Str(), "https://fuel.gazebosim.org");
     EXPECT_EQ(id.Server().Version(), "1.0");
     EXPECT_EQ(id.Owner(), "openrobotics");
     EXPECT_EQ(id.Name(), "empty");
@@ -1063,7 +1069,7 @@ TEST_F(FuelClientTest, ParseWorldFileUrl)
 
 //////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
+// https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(FuelClientTest, DownloadWorld)
 {
   // Configure to use binary path as cache
@@ -1073,7 +1079,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
   ServerConfig server;
   server.SetUrl(common::URI(
-        "https://fuel.ignitionrobotics.org"));
+        "https://fuel.gazebosim.org"));
 
   ClientConfig config;
   config.AddServer(server);
@@ -1086,7 +1092,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Download world from URL
   {
     // Unversioned URL should get the latest available version
-    common::URI url{"https://fuel.ignitionrobotics.org/1.0/OpenRobotics/"
+    common::URI url{"https://fuel.gazebosim.org/1.0/OpenRobotics/"
                     "worlds/Test world"};
 
     // Check it is not cached
@@ -1103,7 +1109,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
     // Check it was downloaded to `1`
     auto worldPath = common::joinPaths(common::cwd(), "test_cache",
-        "fuel.ignitionrobotics.org", "openrobotics", "worlds", "test world");
+        "fuel.gazebosim.org", "openrobotics", "worlds", "test world");
 
     EXPECT_EQ(path, common::joinPaths(worldPath, "2"));
     EXPECT_TRUE(common::exists(common::joinPaths(worldPath, "2")));
@@ -1122,7 +1128,7 @@ TEST_F(FuelClientTest, DownloadWorld)
   // Try using nonexistent URL
   {
     common::URI url{
-        "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Bad world"};
+        "https://fuel.gazebosim.org/1.0/OpenRobotics/worlds/Bad world"};
     std::string path;
     auto result = client.DownloadWorld(url, path);
     EXPECT_FALSE(result);
@@ -1141,7 +1147,7 @@ TEST_F(FuelClientTest, DownloadWorld)
 
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/106
+// https://github.com/gazebosim/gz-fuel-tools/issues/106
 TEST_F(FuelClientTest, CachedWorld)
 {
   // Configure to use binary path as cache and populate it
@@ -1331,7 +1337,7 @@ TEST_F(FuelClientTest, WorldDetails)
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
+// https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(FuelClientTest, Models)
 {
   ClientConfig config;
@@ -1351,7 +1357,7 @@ TEST_F(FuelClientTest, Models)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     ModelIter iter = client.Models(serverConfig);
     EXPECT_TRUE(iter);
   }
@@ -1365,7 +1371,7 @@ TEST_F(FuelClientTest, Models)
 
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
-// https://github.com/ignitionrobotics/ign-fuel-tools/issues/105
+// https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(FuelClientTest, Worlds)
 {
   ClientConfig config;
@@ -1385,7 +1391,7 @@ TEST_F(FuelClientTest, Worlds)
   }
 
   {
-    // Uses fuel.ignitionrobotics.org by default
+    // Uses fuel.gazebosim.org by default
     WorldIter iter = client.Worlds(serverConfig);
     EXPECT_TRUE(iter);
   }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

This helps to fix #315 by using models that have been reduced in size. The changed models had their images and meshes removed, and move to the `openroboticstest` account on Fuel.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.