### PR TITLE
Fix model downloads for ignitionrobotics.org URIs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -2,7 +2,7 @@
 
 ### Depercations
 
-1. The `fuel.gazebosim.org` Fuel server has been deprecated, and
+1. The `fuel.ignitionrobotics.org` Fuel server has been deprecated, and
     redirects to `fuel.gazebosim.org`. Use `fuel.gazebosim.org` in all Fuel
     URLs.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,8 +71,10 @@ ign_build_tests(TYPE UNIT
                   TINYXML2::TINYXML2
 )
 
-# The default timeout (240s) doesn't seem to be enough for this test.
-set_tests_properties(UNIT_FuelClient_TEST PROPERTIES TIMEOUT 360)
+if (TARGET UNIT_FuelClient_TEST)
+  # The default timeout (240s) doesn't seem to be enough for this test.
+  set_tests_properties(UNIT_FuelClient_TEST PROPERTIES TIMEOUT 360)
+endif()
 
 # Command line support.
 add_subdirectory(cmd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,5 +71,8 @@ ign_build_tests(TYPE UNIT
                   TINYXML2::TINYXML2
 )
 
+# The default timeout (240s) doesn't seem to be enough for this test.
+set_tests_properties(UNIT_FuelClient_TEST PROPERTIES TIMEOUT 360)
+
 # Command line support.
 add_subdirectory(cmd)

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -45,11 +45,13 @@ class gz::fuel_tools::ClientConfigPrivate
 
             this->servers.push_back(ServerConfig());
 
-            // Add in fuel.gazebosim.org as another default server config.
-            ServerConfig gzServerConfig;
-            gzServerConfig.SetUrl(common::URI("https://fuel.gazebosim.org"));
-            gzServerConfig.SetVersion("1.0");
-            this->servers.push_back(gzServerConfig);
+            // Add in fuel.ignitionrobotics.org as another default server
+            // config.
+            ServerConfig ignServerConfig;
+            ignServerConfig.SetUrl(
+                common::URI("https://fuel.ignitionrobotics.org"));
+            ignServerConfig.SetVersion("1.0");
+            this->servers.push_back(ignServerConfig);
           }
 
   /// \brief Clear values.

--- a/src/ClientConfig_TEST.cc
+++ b/src/ClientConfig_TEST.cc
@@ -100,7 +100,7 @@ TEST(ClientConfig, CustomDefaultConfiguration)
   ASSERT_EQ(2u, config.Servers().size());
   EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
-  EXPECT_EQ("https://fuel.gazebosim.org",
+  EXPECT_EQ("https://fuel.ignitionrobotics.org",
     config.Servers()[1].Url().Str());
 
   std::string defaultCacheLocation = common::joinPaths(
@@ -139,7 +139,7 @@ TEST(ClientConfig, CustomConfiguration)
   ASSERT_EQ(4u, config.Servers().size());
   EXPECT_EQ("https://fuel.gazebosim.org",
     config.Servers().front().Url().Str());
-  EXPECT_EQ("https://fuel.gazebosim.org",
+  EXPECT_EQ("https://fuel.ignitionrobotics.org",
     config.Servers()[1].Url().Str());
   EXPECT_EQ("https://api.ignitionfuel.org",
     config.Servers()[2].Url().Str());


### PR DESCRIPTION
# 🦟 Bug fix

Might fix: https://github.com/gazebosim/gazebo-classic/issues/3288
Fixes problem mentioned in: https://answers.gazebosim.org/question/28699/ignition-gazebo-citadel-can-no-longer-load-worlds-from-fuelgazebosimorg/

## Summary
The FuelClient library was only looking for models in `~/.ignition/fuel/fuel.gazebosim.org` regardless of which server models were downloaded from when checking if a model is cached. This caused models that used the deprecated `ignitionrobotics.org` URI to be redownloaded every time. This PR fixes it by adding `ignitionrobotics.org` as an additional server to check.

It also seems like when a cache isn't found, the file path returned uses the `tip` leaf directory instead of the actual version number. Since the `tip` directory never exists, gazebo fails with a file not found error. This seems like an error condition that should be handled differently, but that's not in the scope of this PR.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- ~[ ] Consider updating Python bindings (if the library has them)~
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
