### PR TITLE
port: 7 to 8 2023-01-25

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,11 @@
 
 ## Gazebo Fuel Tools 7.x
 
+### Gazebo Fuel Tools 7.2.0 (2021-11-17)
+
+1. Forward port 4.7.0.
+    * [Pull request #306](https://github.com/gazebosim/gz-fuel-tools/pull/306)
+
 ### Gazebo Fuel Tools 7.1.0 (2021-08-16)
 
 1. Ignition to Gazebo server rename effort

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -397,10 +397,10 @@ TEST_P(DownloadCollectionTest, AllItems)
       "openroboticstest", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
     common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
-      "openroboticstest", "models", "backpack", "2")));
+      "openroboticstest", "models", "backpack", "3")));
   EXPECT_TRUE(common::isFile(
     common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
-      "openroboticstest", "models", "backpack", "2", "model.sdf")));
+      "openroboticstest", "models", "backpack", "3", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(
@@ -460,10 +460,10 @@ TEST_P(DownloadCollectionTest, Models)
       "openroboticstest", "models", "backpack")));
   EXPECT_TRUE(common::isDirectory(
     common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
-      "openroboticstest", "models", "backpack", "2")));
+      "openroboticstest", "models", "backpack", "3")));
   EXPECT_TRUE(common::isFile(
     common::joinPaths(this->testCachePath, "fuel.gazebosim.org",
-      "openroboticstest", "models", "backpack", "2", "model.sdf")));
+      "openroboticstest", "models", "backpack", "3", "model.sdf")));
 
   // Model: TEAMBASE
   EXPECT_TRUE(common::isDirectory(


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

# ➡️ Forward port

Port ign-fuel-tools7 to gz-fuel-tools8

Branch comparison: https://github.com/gazebosim/gz-fuel-tools/compare/gz-fuel-tools8...ign-fuel-tools7 

> This PR applies https://github.com/gazebosim/gz-fuel-tools/pull/319 to gz-fuel-tools8

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)
