### PR TITLE
Update package deps for harmonic

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -4,7 +4,7 @@ libgflags-dev
 libgz-cmake3-dev
 libgz-common5-dev
 libgz-math7-dev
-libgz-msgs9-dev
+libgz-msgs10-dev
 libgz-tools2-dev
 libgz-utils2-dev
 libjsoncpp-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ project(gz-fuel_tools9 VERSION 9.0.0)
 # Find gz-cmake
 #============================================================================
 # If you get an error at this line, you need to install gz-cmake
-find_package(gz-cmake4 REQUIRED)
-set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
+find_package(gz-cmake3 REQUIRED)
+set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 
 #============================================================================
 # Configure the project
@@ -49,18 +49,18 @@ gz_find_package(ZIP REQUIRED PRIVATE)
 
 #--------------------------------------
 # Find gz-utils
-gz_find_package(gz-utils3 REQUIRED)
-set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
+gz_find_package(gz-utils2 REQUIRED)
+set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-common
-gz_find_package(gz-common6 REQUIRED PRIVATE)
-set(GZ_COMMON_VER ${gz-common6_VERSION_MAJOR})
+gz_find_package(gz-common5 REQUIRED PRIVATE)
+set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-math
-gz_find_package(gz-math8 REQUIRED PRIVATE)
-set(GZ_MATH_VER ${gz-math8_VERSION_MAJOR})
+gz_find_package(gz-math7 REQUIRED PRIVATE)
+set(GZ_MATH_VER ${gz-math7_VERSION_MAJOR})
 
 #--------------------------------------
 # Find gz-msgs

--- a/tutorials/01_installation.md
+++ b/tutorials/01_installation.md
@@ -90,7 +90,7 @@ sudo apt-get remove libgz-fuel-tools<#>-dev
 Install prerequisites. A clean Ubuntu system will need:
 
 ```
-sudo apt-get install git cmake pkg-config python ruby-ronn libgz-cmake3-dev libgz-common5-dev libgz-math7-dev libgz-msgs9-dev libgz-tools2-dev libzip-dev libjsoncpp-dev libcurl4-openssl-dev libyaml-dev
+sudo apt-get install git cmake pkg-config python ruby-ronn libgz-cmake3-dev libgz-common5-dev libgz-math7-dev libgz-msgs10-dev libgz-tools2-dev libzip-dev libjsoncpp-dev libcurl4-openssl-dev libyaml-dev
 ```
 
 Clone the repository into a directory and go into it:


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Now that msgs and transport are recently bumped (to msgs10 and transport13) in harmonic, we need to bump all packages that depend on them. In this case, harmonic should now use fuel-tools9. 

I noticed that the package dependency versions were bumped in `main` in https://github.com/gazebosim/gz-fuel-tools/commit/83077ca167f2b24cf8bd23f7c016c36db5f68b1b. Here I'm just updating all of them to correspond to the correct gz package versions that we currently use in harmonic

Related PR: 
* https://github.com/gazebo-tooling/gazebodistro/pull/131
* https://github.com/gazebo-tooling/release-tools/pull/876
* https://github.com/osrf/homebrew-simulation/pull/2203


# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

