### PR TITLE
Add support for following redirects when downloading assets from Fuel Server

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -284,6 +284,12 @@ RestResponse Rest::Request(HttpMethod _method,
   // Set the default value: do not prove that SSL certificate is authentic
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 
+  // Follow redirects to any URL set on the Location header.
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+  // Set cURL to only follow 3 redirects tops.
+  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
+
   std::ifstream ifs;
   struct curl_httppost *formpost = nullptr;
 


### PR DESCRIPTION
# 🎉 Add support for following HTTP redirects when downloading assets from Fuel Server

## Summary
This PR implements the cURL options needed to indicate that cURL should follow the `Location` header when an HTTP server returns a `3xx` status code.

We're introducing a new mechanism to improve the throughput when downloading Models and Worlds from fuel server. This new mechanism implements a redirection to another server that provides the zip file. This PR implements that change in the client, as it doesn't have native support for redirects.

The documentation associated to the options applied in this PR can be found here:
- https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html
- https://curl.se/libcurl/c/CURLOPT_MAXREDIRS.html

## Test it
Try downloading the following asset (https://staging-app.gazebosim.org/marcoshuck5/fuel/models/testcoro) using a new version of this tool but with the changes included in this branch.

I haven't tested this yet, as I couldn't build the application locally. This is my first contribution.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
