### PR TITLE
Allow Curl redirect on get

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -286,17 +286,19 @@ RestResponse Rest::Request(HttpMethod _method,
   // Set the default value: do not prove that SSL certificate is authentic
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 
+  // Follow redirects to any URL set on the Location header.
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+  // Set cURL to only follow 3 redirects tops.
+  curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
+
   std::ifstream ifs;
   struct curl_httppost *formpost = nullptr;
 
   // Send the request.
   if (_method == HttpMethod::GET)
   {
-    // Follow redirects to any URL set on the Location header.
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-
-    // Set cURL to only follow 3 redirects tops.
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
+    // no need to do anything
   }
   else if (_method == HttpMethod::PATCH_FORM)
   {

--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -292,7 +292,11 @@ RestResponse Rest::Request(HttpMethod _method,
   // Send the request.
   if (_method == HttpMethod::GET)
   {
-    // no need to do anything
+    // Follow redirects to any URL set on the Location header.
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+    // Set cURL to only follow 3 redirects tops.
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
   }
   else if (_method == HttpMethod::PATCH_FORM)
   {


### PR DESCRIPTION
# 🎉 New feature

## Summary

Retargeting #330 to Citadel. See #330 for more information about redirects.

I'm scoping this change to only GET requests.

## Test it

Try running the following command. The Staging Fuel server is setup to redirect requests to S3.

```
ign fuel download -u https://staging-fuel.gazebosim.org/1.0/marcoshuck5/models/testcoro
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
