### PR TITLE
Support link referral download

### DIFF
--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -34,6 +34,7 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
+#include <gz/common/URI.hh>
 #include <gz/common/Util.hh>
 
 #include <gz/msgs/Utility.hh>
@@ -191,6 +192,11 @@ class gz::fuel_tools::FuelClientPrivate
   /// \param[in] _uri URI to check
   /// DEPRECATED/DEPRECATION: remove this function in Gazebo H.
   public: void CheckForDeprecatedUri(const common::URI &_uri);
+
+  /// \brief Get zip data from a REST response. This is used by world and
+  /// model download.
+  public: void ZipFromResponse(const RestResponse &_resp,
+              std::string &_zip);
 
   /// \brief Client configuration
   public: ClientConfig config;
@@ -623,7 +629,7 @@ Result FuelClient::DownloadModel(const ModelIdentifier &_id,
   Rest rest;
   RestResponse resp;
   resp = rest.Request(HttpMethod::GET, _id.Server().Url().Str(),
-      _id.Server().Version(), route.Str(), {},
+      _id.Server().Version(), route.Str(), {"link=true"},
       headersIncludingServerConfig, "");
   if (resp.statusCode != 200)
   {
@@ -657,9 +663,17 @@ Result FuelClient::DownloadModel(const ModelIdentifier &_id,
   }
   newId.SetVersion(version);
 
+  std::string zipData;
+  this->dataPtr->ZipFromResponse(resp, zipData);
+
   // Save
   // Note that the save function doesn't return the path
-  if (!this->dataPtr->cache->SaveModel(newId, resp.data, true))
+  if (!zipData.empty())
+  {
+    if (!this->dataPtr->cache->SaveModel(newId, zipData, true))
+      return Result(ResultType::FETCH_ERROR);
+  }
+  else
     return Result(ResultType::FETCH_ERROR);
 
   return this->ModelDependencies(_id, _dependencies);
@@ -792,7 +806,7 @@ Result FuelClient::DownloadWorld(WorldIdentifier &_id)
   Rest rest;
   RestResponse resp;
   resp = rest.Request(HttpMethod::GET, _id.Server().Url().Str(),
-      _id.Server().Version(), route.Str(), {},
+      _id.Server().Version(), route.Str(), {"link=true"},
       headersIncludingServerConfig, "");
   if (resp.statusCode != 200)
   {
@@ -826,9 +840,19 @@ Result FuelClient::DownloadWorld(WorldIdentifier &_id)
   }
   _id.SetVersion(version);
 
+  std::string zipData;
+  this->dataPtr->ZipFromResponse(resp, zipData);
+
   // Save
-  if (!this->dataPtr->cache->SaveWorld(_id, resp.data, true))
+  if (!zipData.empty())
+  {
+    if (!this->dataPtr->cache->SaveWorld(_id, zipData, true))
+      return Result(ResultType::FETCH_ERROR);
+  }
+  else
+  {
     return Result(ResultType::FETCH_ERROR);
+  }
 
   return Result(ResultType::FETCH);
 }
@@ -1804,3 +1828,65 @@ void FuelClientPrivate::CheckForDeprecatedUri(const common::URI &_uri)
   }
 }
 
+//////////////////////////////////////////////////
+void FuelClientPrivate::ZipFromResponse(const RestResponse &_resp,
+    std::string &_zip)
+{
+  // Check the content-type which could be empty (ideally not), text/plain
+  // which indicates the data is a download link, application/zip which
+  // indicates the data is a zip file, or binary/octet-stream which also
+  // indicates the data is a zip file.
+  auto contentTypeIter = _resp.headers.find("Content-Type");
+  if (contentTypeIter != _resp.headers.end())
+  {
+    // If text/plain then data might be a link to a zip file.
+    if (contentTypeIter->second.find("text/plain") != std::string::npos)
+    {
+      std::string linkUri = _resp.data;
+
+      // Check for valid URI
+      if (common::URI::Valid(linkUri))
+      {
+        igndbg << "Downloading from a referal link[" << linkUri << "]\n";
+        // Get the zip data.
+        RestResponse linkResp = rest.Request(HttpMethod::GET,
+            // URL
+            linkUri,
+            // Version
+            "",
+            // Path
+            "",
+            // Query strings
+            {},
+            // Headers
+            {},
+            // Data
+            "");
+
+        return this->ZipFromResponse(linkResp, _zip);
+      }
+      else
+      {
+        ignerr << "Invalid referal link URI[" << linkUri << "]. "
+          << "Unable to download.\n";
+      }
+    }
+    else if (contentTypeIter->second.find("application/zip") !=
+             std::string::npos ||
+             contentTypeIter->second.find("binary/octet-stream") !=
+             std::string::npos)
+    {
+      _zip = std::move(_resp.data);
+    }
+    else
+    {
+      ignerr << "Invalid content-type of [" << contentTypeIter->second << "]. "
+        << "Unable to download.\n";
+    }
+  }
+  else
+  {
+    // If content-type is missing, then assume the data is the zip file.
+    _zip = std::move(_resp.data);
+  }
+}

--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -212,19 +212,25 @@ RestResponse Rest::Request(HttpMethod _method,
   if (_url.empty())
     return res;
 
-  std::string url = RestJoinUrl(_url, _version);
+  std::string url = _url;
+  if (!_version.empty())
+    url = RestJoinUrl(_url, _version);
 
   CURL *curl = curl_easy_init();
+  char *encodedPath = nullptr;
 
-  // First, unescape the _path since it might have %XX encodings. If this
-  // step is not performed, then curl_easy_escape will encode the %XX
-  // encodings resulting in an incorrect URL.
-  int decodedSize;
-  char *decodedPath = curl_easy_unescape(curl,
-      _path.c_str(), _path.size(), &decodedSize);
+  if (!_path.empty())
+  {
+    // First, unescape the _path since it might have %XX encodings. If this
+    // step is not performed, then curl_easy_escape will encode the %XX
+    // encodings resulting in an incorrect URL.
+    int decodedSize;
+    char *decodedPath = curl_easy_unescape(curl,
+        _path.c_str(), _path.size(), &decodedSize);
 
-  char *encodedPath = curl_easy_escape(curl, decodedPath, decodedSize);
-  url = RestJoinUrl(url, encodedPath);
+    encodedPath = curl_easy_escape(curl, decodedPath, decodedSize);
+    url = RestJoinUrl(url, encodedPath);
+  }
 
   // Process query strings.
   if (!_queryStrings.empty())
@@ -358,7 +364,8 @@ RestResponse Rest::Request(HttpMethod _method,
     curl_formfree(formpost);
 
   // free encoded path char*
-  curl_free(encodedPath);
+  if (encodedPath)
+    curl_free(encodedPath);
 
   // free the headers
   curl_slist_free_all(headers);


### PR DESCRIPTION
# 🎉 New feature

This is a new feature that allows FuelTools to download models and worlds from a link referral. This will allow the fuel server to respond to a download request with a URL to an S3 asset. Historically, the fuel server would serve zip files directly. This approach can lead to bottlenecks and download failures with increased load. Offloading zip file handling to S3 will improve download reliability.
 
The fuel server will maintain its current behavior, and only return a referral link if the `?link=true` query parameter is used. Here is the [corresponding fuel server PR](https://github.com/gazebo-web/fuel-server/pull/15).

It's safe to merge this prior to the fuel server PR, since it doesn't break behavior.
## Test it

`staging-fuel.gazebosim.org` is setup to serve referral links, while production has not been changed.

You can try using links with:

```
ign fuel download -v4 -u https://staging-fuel.gazebosim.org/1.0/marcoshuck5/models/testcoro
```

You can confirm old behavior works with:

```
ign fuel download -v4 -u https://fuel.gazebosim.org/1.0/openrobotics/models/backpack
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.