### PR TITLE
Forward port 4 to 7 (Just changelog)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -199,6 +199,15 @@
 
 ## Gazebo Fuel Tools 4.x
 
+### Gazebo Fuel Tools 4.8.2 (2023-03-21)
+
+1. Allow Curl redirect on get.
+    * [Pull request #331](https://github.com/gazebosim/gz-fuel-tools/pull/331)
+
+1. CI and license updates.
+    * [Pull request #334](https://github.com/gazebosim/gz-fuel-tools/pull/334)
+    * [Pull request #335](https://github.com/gazebosim/gz-fuel-tools/pull/335)
+
 ### Gazebo Fuel Tools 4.8.1 (2023-02-07)
 
 1. Fix model downloads for ignitionrobotics.org URIs.


### PR DESCRIPTION
# ➡️ Forward port

This is just a changelog, so I'll go ahead and merge this asap.
Port ign-fuel-tools4 to ign-fuel-tools7

Branch comparison: [https://github.com/gazebosim/<REPO>/compare/<TO_BRANCH>...<FROM_BRANCH>](https://github.com/gazebosim/gz-fuel-tools/compare/ign-fuel-tools7...ign-fuel-tools4)

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)