### PR TITLE
Reflect pagination of RESTful requests in iterator API 

### DIFF
--- a/include/gz/fuel_tools/FuelClient.hh
+++ b/include/gz/fuel_tools/FuelClient.hh
@@ -132,18 +132,18 @@ namespace ignition
       /// \brief Returns models matching a given identifying criteria
       /// \param[in] _id a partially filled out identifier used to fetch models
       /// \remarks Fulfills Get-One requirement
-      /// \remarks It's not yet clear if model names are unique, so this API
+      /// \remarks Model names are unique to the owner, so this API
       ///          allows the possibility of getting multiple models with the
-      ///          same name.
+      ///          same name if the owner is not specified.
       /// \return An iterator of models with names matching the criteria
       public: ModelIter Models(const ModelIdentifier &_id);
 
       /// \brief Returns models matching a given identifying criteria
       /// \param[in] _id a partially filled out identifier used to fetch models
       /// \remarks Fulfills Get-One requirement
-      /// \remarks It's not yet clear if model names are unique, so this API
+      /// \remarks Model names are unique to the owner, so this API
       ///          allows the possibility of getting multiple models with the
-      ///          same name.
+      ///          same name if the owner is not specified.
       /// \return An iterator of models with names matching the criteria
       public: ModelIter Models(const ModelIdentifier &_id) const;
 
@@ -151,9 +151,9 @@ namespace ignition
       /// \param[in] _id a partially filled out identifier used to fetch models
       /// \param[in] _checkCache Whether to check the cache.
       /// \remarks Fulfills Get-One requirement
-      /// \remarks It's not yet clear if model names are unique, so this API
+      /// \remarks Model names are unique to the owner, so this API
       ///          allows the possibility of getting multiple models with the
-      ///          same name.
+      ///          same name if the owner is not specified.
       /// \return An iterator of models with names matching the criteria
       public: ModelIter Models(const ModelIdentifier &_id, bool _checkCache);
 
@@ -161,9 +161,9 @@ namespace ignition
       /// \param[in] _id a partially filled out identifier used to fetch models
       /// \param[in] _checkCache Whether to check the cache.
       /// \remarks Fulfills Get-One requirement
-      /// \remarks It's not yet clear if model names are unique, so this API
+      /// \remarks Model names are unique to the owner, so this API
       ///          allows the possibility of getting multiple models with the
-      ///          same name.
+      ///          same name if the owner is not specified.
       /// \return An iterator of models with names matching the criteria
       public: ModelIter Models(const ModelIdentifier &_id,
                                bool _checkCache) const;

--- a/include/gz/fuel_tools/FuelClient.hh
+++ b/include/gz/fuel_tools/FuelClient.hh
@@ -147,10 +147,31 @@ namespace ignition
       /// \return An iterator of models with names matching the criteria
       public: ModelIter Models(const ModelIdentifier &_id) const;
 
-      /// \brief Returns an iterator for the models found in a collection.
-      /// \param[in] _id a partially filled out identifier used to fetch a
-      /// collection.
-      /// \return An iterator of models in the collection.
+      /// \brief Returns models matching a given identifying criteria
+      /// \param[in] _id a partially filled out identifier used to fetch models
+      /// \param[in] _checkCache Whether to check the cache.
+      /// \remarks Fulfills Get-One requirement
+      /// \remarks It's not yet clear if model names are unique, so this API
+      ///          allows the possibility of getting multiple models with the
+      ///          same name.
+      /// \return An iterator of models with names matching the criteria
+      public: ModelIter Models(const ModelIdentifier &_id, bool _checkCache);
+
+      /// \brief Returns models matching a given identifying criteria
+      /// \param[in] _id a partially filled out identifier used to fetch models
+      /// \param[in] _checkCache Whether to check the cache.
+      /// \remarks Fulfills Get-One requirement
+      /// \remarks It's not yet clear if model names are unique, so this API
+      ///          allows the possibility of getting multiple models with the
+      ///          same name.
+      /// \return An iterator of models with names matching the criteria
+      public: ModelIter Models(const ModelIdentifier &_id,
+                               bool _checkCache) const;
+
+       /// \brief Returns an iterator for the models found in a collection.
+       /// \param[in] _id a partially filled out identifier used to fetch a
+       /// collection.
+       /// \return An iterator of models in the collection.
       public: ModelIter Models(const CollectionIdentifier &_id) const;
 
       /// \brief Returns worlds matching a given identifying criteria

--- a/include/gz/fuel_tools/ModelIterPrivate.hh
+++ b/include/gz/fuel_tools/ModelIterPrivate.hh
@@ -152,24 +152,30 @@ namespace ignition
 
       /// \brief RESTful client
       public: Rest rest;
+
+      /// \brief The API (path) of the RESTful requests
       public: const std::string api;
 
-      using IdListIterator = std::vector<ModelIdentifier>::iterator;
-
+      /// \brief Make a RESTful request for the given page
+      /// \param[in] _page Page number to request
+      /// \return Response from the request
       protected: RestResponse MakeRestRequest(std::size_t _page);
-      protected: void SetModelFromIdIter(IdListIterator iter);
+
+      /// \brief Parse model identifiers from a RESTful response
+      /// \param[in] _resp RESTful response
+      /// \return A vector of identifiers extracted from the response.
       protected: std::vector<ModelIdentifier> ParseIdsFromResponse(
-          const RestResponse &resp);
+          const RestResponse &_resp);
 
       /// \brief Model identifiers in the current page
       protected: std::vector<ModelIdentifier> ids;
 
       /// \brief Where the current iterator is in the list of ids
-      protected: IdListIterator idIter;
+      protected: std::vector<ModelIdentifier>::iterator idIter;
 
       /// \brief Keep track of page number for pagination of response data from
       /// server.
-      protected: std::size_t currentPage{1};
+      protected: std::size_t currentPage{0};
     };
   }
 }

--- a/include/gz/fuel_tools/ModelIterPrivate.hh
+++ b/include/gz/fuel_tools/ModelIterPrivate.hh
@@ -130,7 +130,7 @@ namespace ignition
     };
 
     /// \brief class for iterating through model ids from a rest API
-    class IGNITION_FUEL_TOOLS_VISIBLE IterRestIds: public ModelIterPrivate
+    class IGNITION_FUEL_TOOLS_HIDDEN IterRestIds: public ModelIterPrivate
     {
       /// \brief constructor
       public: IterRestIds(const Rest &_rest,
@@ -152,12 +152,24 @@ namespace ignition
 
       /// \brief RESTful client
       public: Rest rest;
+      public: const std::string api;
+
+      using IdListIterator = std::vector<ModelIdentifier>::iterator;
+
+      protected: RestResponse MakeRestRequest(std::size_t _page);
+      protected: void SetModelFromIdIter(IdListIterator iter);
+      protected: std::vector<ModelIdentifier> ParseIdsFromResponse(
+          const RestResponse &resp);
 
       /// \brief Model identifiers in the current page
       protected: std::vector<ModelIdentifier> ids;
 
       /// \brief Where the current iterator is in the list of ids
-      protected: std::vector<ModelIdentifier>::iterator idIter;
+      protected: IdListIterator idIter;
+
+      /// \brief Keep track of page number for pagination of response data from
+      /// server.
+      protected: std::size_t currentPage{1};
     };
   }
 }

--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -378,16 +378,31 @@ WorldIter FuelClient::Worlds(const ServerConfig &_server) const
 //////////////////////////////////////////////////
 ModelIter FuelClient::Models(const ModelIdentifier &_id)
 {
-  return const_cast<const FuelClient*>(this)->Models(_id);
+  return this->Models(_id, true);
 }
 
 //////////////////////////////////////////////////
 ModelIter FuelClient::Models(const ModelIdentifier &_id) const
 {
-  // Check local cache first
-  ModelIter localIter = this->dataPtr->cache->MatchingModels(_id);
-  if (localIter)
-    return localIter;
+  return this->Models(_id, true);
+}
+
+//////////////////////////////////////////////////
+ModelIter FuelClient::Models(const ModelIdentifier &_id, bool _checkCache)
+{
+  return const_cast<const FuelClient*>(this)->Models(_id, _checkCache);
+}
+
+//////////////////////////////////////////////////
+ModelIter FuelClient::Models(const ModelIdentifier &_id, bool _checkCache) const
+{
+  if (_checkCache)
+  {
+    // Check local cache first
+    ModelIter localIter = this->dataPtr->cache->MatchingModels(_id);
+    if (localIter)
+      return localIter;
+  }
 
   // TODO(nkoenig) try to fetch model directly from a server
   // Note: ign-fuel-server doesn't like URLs ending in /
@@ -398,7 +413,7 @@ ModelIter FuelClient::Models(const ModelIdentifier &_id) const
     path = path / _id.Owner() / "models";
 
   if (path.Str().empty())
-    return localIter;
+    return ModelIterFactory::Create();
 
   ignmsg << _id.UniqueName() << " not found in cache, attempting download\n";
 

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -1384,6 +1384,52 @@ TEST_F(FuelClientTest, Models)
   }
 }
 
+//////////////////////////////////////////////////
+TEST_F(FuelClientTest, ModelsCheckCached)
+{
+  ClientConfig config;
+  std::string cacheDir = common::joinPaths(PROJECT_BINARY_PATH, "test_cache");
+  common::removeAll(cacheDir );
+  ASSERT_TRUE(common::createDirectories(cacheDir));
+  config.SetCacheLocation(cacheDir);
+  FuelClient client(config);
+  ServerConfig serverConfig;
+  ModelIdentifier modelId;
+  modelId.SetOwner("openroboticstest");
+  std::vector<Model> modelInfos;
+  {
+    for (ModelIter iter = client.Models(modelId, true); iter; ++iter)
+    {
+      modelInfos.push_back(*iter);
+    }
+  }
+  ASSERT_FALSE(modelInfos.empty());
+  // Download one of the models to test the behavior of Models() with
+  // different values for _checkCache
+  EXPECT_TRUE(client.DownloadModel(modelInfos.front().Identification()));
+  {
+    std::size_t counter = 0;
+    for (ModelIter iter = client.Models(modelId, true); iter; ++iter, ++counter)
+    {
+    }
+    std::cout << "counter: " << counter << std::endl;
+    // Expect only one result with checkCache=true because we've downloaded only
+    // one model
+    EXPECT_EQ(counter, 1u);
+    EXPECT_GT(modelInfos.size(), counter);
+  }
+
+  {
+    std::size_t counter = 0;
+    for (ModelIter iter = client.Models(modelId, false); iter;
+         ++iter, ++counter)
+    {
+    }
+    std::cout << "counter: " << counter << std::endl;
+    EXPECT_EQ(counter, modelInfos.size());
+  }
+}
+
 /////////////////////////////////////////////////
 // Protocol "https" not supported or disabled in libcurl for Windows
 // https://github.com/gazebosim/gz-fuel-tools/issues/105

--- a/src/ModelIter.cc
+++ b/src/ModelIter.cc
@@ -195,7 +195,6 @@ void IterRestIds::Next()
   if (this->idIter == this->ids.end())
   {
     ++this->currentPage;
-    std::cout << "Getting page " << currentPage << std::endl;
     RestResponse resp = this->MakeRestRequest(this->currentPage);
     this->ids = this->ParseIdsFromResponse(resp);
     this->idIter = this->ids.begin();

--- a/src/ModelIter.cc
+++ b/src/ModelIter.cc
@@ -147,58 +147,55 @@ IterRestIds::~IterRestIds()
 {
 }
 
+std::vector<ModelIdentifier> IterRestIds::ParseIdsFromResponse(
+    const RestResponse &resp)
+{
+  if (resp.data == "null\n" || resp.statusCode != 200)
+    return {};
+
+  // Parse the response.
+  return JSONParser::ParseModels(resp.data, this->config);
+}
+
 //////////////////////////////////////////////////
 IterRestIds::IterRestIds(const Rest &_rest, const ServerConfig &_config,
     const std::string &_api)
-  : config(_config), rest(_rest)
+  : config(_config), rest(_rest), api(_api)
 {
-  HttpMethod method = HttpMethod::GET;
-  this->config = _config;
-  int page = 1;
-  std::vector<std::string> headers = {"Accept: application/json"};
-  RestResponse resp;
-  std::vector<ModelIdentifier> modelIds;
-  this->ids.clear();
-
-  do
-  {
-    // Prepare the request with the next page.
-    std::string queryStrPage = "page=" + std::to_string(page);
-    std::string path = _api;
-    ++page;
-
-    // Fire the request.
-    resp = this->rest.Request(method, this->config.Url().Str(),
-      this->config.Version(),
-      std::regex_replace(path, std::regex(R"(\\)"), "/"),
-      {queryStrPage}, headers, "");
-
-    // TODO(nkoenig): resp.statusCode should return != 200 when the page
-    // requested does
-    // not exist. When this happens we should stop without calling ParseModels()
-    if (resp.data == "null\n" || resp.statusCode != 200)
-      break;
-
-    // Parse the response.
-    modelIds = JSONParser::ParseModels(resp.data, this->config);
-
-    // Add the vector of models to the list.
-    this->ids.insert(std::end(this->ids), std::begin(modelIds),
-      std::end(modelIds));
-  } while (!modelIds.empty());
+  RestResponse resp = this->MakeRestRequest(this->currentPage);
+  this->ids = this->ParseIdsFromResponse(resp);
+  this->idIter = this->ids.begin();
 
   if (this->ids.empty())
     return;
-
-  this->idIter = this->ids.begin();
-
   // make first model
+  this->SetModelFromIdIter(this->idIter);
+}
+
+//////////////////////////////////////////////////
+void IterRestIds::SetModelFromIdIter(IdListIterator iter)
+{
   std::shared_ptr<ModelPrivate> ptr(new ModelPrivate);
-  ptr->id = *(this->idIter);
+  ptr->id = *iter;
   ptr->id.SetServer(this->config);
   this->model = Model(ptr);
+}
 
-  igndbg << "Got response [" << resp.data << "]\n";
+//////////////////////////////////////////////////
+RestResponse IterRestIds::MakeRestRequest(std::size_t _page)
+{
+  HttpMethod method = HttpMethod::GET;
+  std::vector<std::string> headers = {"Accept: application/json"};
+  std::vector<ModelIdentifier> modelIds;
+  // Prepare the request with the next page.
+  std::string queryStrPage = "page=" + std::to_string(_page);
+  std::string path = this->api;
+  std::cout << "Getting: " << queryStrPage << std::endl;
+  // Fire the request.
+  return this->rest.Request(method, this->config.Url().Str(),
+      this->config.Version(),
+      std::regex_replace(path, std::regex(R"(\\)"), "/"),
+      {queryStrPage}, headers, "");
 }
 
 //////////////////////////////////////////////////
@@ -207,15 +204,19 @@ void IterRestIds::Next()
   // advance pointer
   ++(this->idIter);
 
+  if (this->idIter == this->ids.end())
+  {
+    ++this->currentPage;
+    RestResponse resp = this->MakeRestRequest(this->currentPage);
+    this->ids = this->ParseIdsFromResponse(resp);
+    this->idIter = this->ids.begin();
+  }
+
   // Update personal model class
   if (this->idIter != this->ids.end())
   {
-    std::shared_ptr<ModelPrivate> ptr(new ModelPrivate);
-    ptr->id = *(this->idIter);
-    ptr->id.SetServer(this->config);
-    this->model = Model(ptr);
+    this->SetModelFromIdIter(this->idIter);
   }
-  // TODO(nkoenig) request next page if api is paginated
 }
 
 //////////////////////////////////////////////////
@@ -256,7 +257,6 @@ ModelIter::operator bool() const
 //////////////////////////////////////////////////
 ModelIter &ModelIter::operator++()
 {
-  // TODO(nkoenig) Request more data if there are more pages
   if (!this->dataPtr->HasReachedEnd())
   {
     this->dataPtr->Next();

--- a/src/ModelIter.cc
+++ b/src/ModelIter.cc
@@ -150,9 +150,6 @@ IterRestIds::~IterRestIds()
 std::vector<ModelIdentifier> IterRestIds::ParseIdsFromResponse(
     const RestResponse &resp)
 {
-  // TODO(nkoenig): resp.statusCode should return != 200 when the page
-  // requested does
-  // not exist. When this happens we should stop without calling ParseModels()
   if (resp.data == "null\n" || resp.statusCode != 200)
     return {};
 
@@ -175,7 +172,7 @@ RestResponse IterRestIds::MakeRestRequest(std::size_t _page)
   HttpMethod method = HttpMethod::GET;
   std::vector<std::string> headers = {"Accept: application/json"};
   std::vector<ModelIdentifier> modelIds;
-  // Prepare the request with the next page.
+  // Prepare the request with the requested page.
   std::string queryStrPage = "page=" + std::to_string(_page);
   std::string path = this->api;
   // Fire the request.


### PR DESCRIPTION
# 🎉 New feature

Toward https://github.com/gazebosim/gz-sim/issues/1253
## Summary

The `ModelIter` iterator was fetching all available pages before making the first model available. This PR makes it so that each page is fetched from Fuel when the iterator is advanced.

This also adds a new member function `FuelClient::Models(onst ModelIdentifier &_id, bool _checkCache)` that allows bypassing the cache when getting a list of models owned by a user from the server. i.e, Currently, we do the following to get a list of models for a user

```c++
  FuelClient client();
  ModelIdentifier modelId;
  modelId.SetOwner("openroboticstest");
  for (ModelIter iter = client.Models(modelId); iter; ++iter)
  { ... }
```
However, if there's even a single model from that owner already downloaded into the cache, `FuelClient::Models` will return just that instead of getting the whole list. If `_checkCache = false`, it skips checking the cache and gets the list from the server.

## Test it
Added `FuelClientTest, ModelsCheckCached`
It's not easy to test pagination, but the `openroboticstest` user has two pages of models currently, so this test should also exercise that code path.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
