### PR TITLE
Deprecated non-relocatable macro

### DIFF
--- a/include/gz/fuel_tools/config.hh.in
+++ b/include/gz/fuel_tools/config.hh.in
@@ -30,6 +30,6 @@
 
 #define GZ_FUEL_TOOLS_VERSION_HEADER "Gazebo Fuel Tools, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2017 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
 
-#define GZ_FUEL_INITIAL_CONFIG_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/"
+#define GZ_FUEL_INITIAL_CONFIG_PATH _Pragma ("GCC warning \"'GZ_FUEL_INITIAL_CONFIG_PATH' macro is deprecated and should not be used. \"") "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/"
 
 #endif


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of https://github.com/gazebosim/gz-sim/issues/626

## Summary

As described in https://github.com/gazebosim/gz-sim/issues/626, we are getting rid of non-relocatable macros. On other libraries this macros have been replaced with functions, but in this case the macro seems unused, so we can simply deprecate it and remove it in a future gz-fuel-tools release. If necessary, relocatable functions can be added in the future.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
