### PR TITLE
Zip: use non-deprecated methods

### DIFF
--- a/src/Zip.cc
+++ b/src/Zip.cc
@@ -37,7 +37,7 @@ bool CompressFile(zip *_archive, const std::string &_file,
 {
   if (common::isDirectory(_file))
   {
-    if (zip_add_dir(_archive, _entry.c_str()) < 0)
+    if (zip_dir_add(_archive, _entry.c_str(), 0) < 0)
     {
       ignerr << "Error adding directory to zip: " << _file << std::endl;
       return false;
@@ -69,7 +69,7 @@ bool CompressFile(zip *_archive, const std::string &_file,
       return false;
     }
 
-    if (zip_add(_archive, _entry.c_str(), source)
+    if (zip_file_add(_archive, _entry.c_str(), source, 0)
         < 0)
     {
       ignerr << "Error adding file to zip: " << _file << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compiler warnings on macOS.

## Summary

This package is using some deprecated methods from `libzip`, which generates compiler warnings as of 1.10.0 (see [release notes](https://github.com/nih-at/libzip/releases/tag/v1.10.0)).

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_fuel-tools-ci-ign-fuel-tools4-homebrew-amd64&build=98)](https://build.osrfoundation.org/view/ign-citadel/job/ignition_fuel-tools-ci-ign-fuel-tools4-homebrew-amd64/98/) https://build.osrfoundation.org/view/ign-citadel/job/ignition_fuel-tools-ci-ign-fuel-tools4-homebrew-amd64/98/clang/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
