### PR TITLE
added script to update assets to gz

### DIFF
--- a/tools/gz-update-assets.py
+++ b/tools/gz-update-assets.py
@@ -13,17 +13,20 @@ import subprocess
 import zipfile
 
 # Replace all occurrences of a string with another string inside all 
-# files matching the file_pattern.
-def find_and_replace(directory, find, replace, file_pattern):
+# files with the provided extension. The extension is treated as
+# case-insentive.
+def find_and_replace(directory, find, replace, extension):
   for root, dirs, files in os.walk(directory):
-    for file in fnmatch.filter(files, file_pattern):
-      filepath = os.path.join(root, file)
-      with open(filepath) as f:
-        contents = f.read()
-      #contents = contents.replace(find, replace)
-      contents = re.sub(find, replace, contents)
-      with open(filepath, "w") as f:
-        f.write(contents)
+    for file in files:
+      base, ext = os.path.splitext(file)
+      if ext.lower() == extension.lower():
+        filepath = os.path.join(root, file)
+        with open(filepath) as f:
+          contents = f.read()
+        #contents = contents.replace(find, replace)
+        contents = re.sub(find, replace, contents)
+        with open(filepath, "w") as f:
+          f.write(contents)
 
 if sys.version_info[0] < 3:
     raise Exception("Python 3 or greater is required. Try running `python3 download_collection.py`")
@@ -104,15 +107,18 @@ while True:
         with zipfile.ZipFile(dl_file, 'r') as zip_ref:
             zip_ref.extractall(model_path)
         # Update plugin names
-        find_and_replace(model_path, "ignition::gazebo::systems", "gz::sim::systems", "*.sdf")
-        find_and_replace(model_path, r"libignition-gazebo-(.*)\.so", r"gz-sim-\1", "*.sdf")
+        find_and_replace(model_path, "ignition::gazebo::systems", "gz::sim::systems", "sdf")
+        find_and_replace(model_path, r"(?:lib)?ignition-gazebo-([^.\s]*)(?:\.so)?", r"gz-sim-\1", "sdf")
+        find_and_replace(model_path, "ignition::gazebo::systems", "gz::sim::systems", "erb")
+        find_and_replace(model_path, r"(?:lib)?ignition-gazebo-([^.\s]*)(?:\.so)?", r"gz-sim-\1", "erb")
+
         # Update fuel server
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.sdf")
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.config")
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.pbtxt")
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.dae")
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.obj")
-        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.mtl")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "sdf")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "config")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "pbtxt")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "dae")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "obj")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "mtl")
         model_url = '{}/{}/{}/models/{}'.format(base_url, fuel_version, owner_name, model_name)
         token_header = 'Private-Token: {}'.format(private_token)
         print("Uploading model {}".format(model_name))

--- a/tools/gz-update-assets.py
+++ b/tools/gz-update-assets.py
@@ -23,7 +23,6 @@ def find_and_replace(directory, find, replace, extension):
         filepath = os.path.join(root, file)
         with open(filepath) as f:
           contents = f.read()
-        #contents = contents.replace(find, replace)
         contents = re.sub(find, replace, contents)
         with open(filepath, "w") as f:
           f.write(contents)

--- a/tools/gz-update-assets.py
+++ b/tools/gz-update-assets.py
@@ -1,0 +1,122 @@
+# Usage
+#     python3 gz-update-assets.py -o <collection_owner> -t <private_token>
+#
+# Description
+#     This script change usage of ignition to gz.
+#
+import sys,json,requests
+import getopt
+import fnmatch
+import os
+import re
+import subprocess
+import zipfile
+
+# Replace all occurrences of a string with another string inside all 
+# files matching the file_pattern.
+def find_and_replace(directory, find, replace, file_pattern):
+  for root, dirs, files in os.walk(directory):
+    for file in fnmatch.filter(files, file_pattern):
+      filepath = os.path.join(root, file)
+      with open(filepath) as f:
+        contents = f.read()
+      #contents = contents.replace(find, replace)
+      contents = re.sub(find, replace, contents)
+      with open(filepath, "w") as f:
+        f.write(contents)
+
+if sys.version_info[0] < 3:
+    raise Exception("Python 3 or greater is required. Try running `python3 download_collection.py`")
+
+owner_name = ''
+private_token = ''
+
+# Read options
+optlist, args = getopt.getopt(sys.argv[1:], 'o:t:')
+
+for o, v in optlist:
+    if o == "-o":
+        owner_name = v.replace(" ", "%20")
+    if o == "-t":
+        private_token = v
+
+if not owner_name:
+    print('Error: missing `-o <owner_name>` option')
+    quit()
+
+if not private_token:
+    print('Error: missing `-t <private_token>` option')
+    quit()
+
+print("Updating models from {}.".format(owner_name))
+
+page = 1
+count = 0
+
+# The Fuel server URL.
+base_url ='https://fuel.gazebosim.org/'
+
+# Fuel server version.
+fuel_version = '1.0'
+
+# Path to get the models in the collection
+next_url = '/{}/models?page={}&per_page=100'.format(owner_name, page)
+
+# Path to download a single model in the collection
+download_url = base_url + fuel_version + '/{}/models/'.format(owner_name)
+
+download_dir = "dl"
+if not os.path.exists(download_dir):
+    os.makedirs(download_dir)
+
+# Iterate over the pages
+while True:
+    url = base_url + fuel_version + next_url
+
+    # Get the contents of the current page.
+    r = requests.get(url)
+
+    if not r or not r.text:
+        break
+
+    # Convert to JSON
+    models = json.loads(r.text)
+
+    # Compute the next page's URL
+    page = page + 1
+    next_url = '/{}/models?page={}&per_page=100'.format(owner_name, page)
+  
+    # Download each model 
+    for model in models:
+        count+=1
+        model_name = model['name']
+        print ('Downloading (%d) %s' % (count, model_name))
+        download = requests.get(download_url+model_name+'.zip', stream=True)
+        file = model_name + '.zip'
+        dl_file = os.path.join(download_dir, file)
+        model_path = os.path.abspath(os.path.join(download_dir, model_name))
+
+        # Download the zip file
+        with open(dl_file, 'wb') as fd:
+            for chunk in download.iter_content(chunk_size=1024*1024):
+                fd.write(chunk)
+        # Extract the zip file
+        with zipfile.ZipFile(dl_file, 'r') as zip_ref:
+            zip_ref.extractall(model_path)
+        # Update plugin names
+        find_and_replace(model_path, "ignition::gazebo::systems", "gz::sim::systems", "*.sdf")
+        find_and_replace(model_path, r"libignition-gazebo-(.*)\.so", r"gz-sim-\1", "*.sdf")
+        # Update fuel server
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.sdf")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.config")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.pbtxt")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.dae")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.obj")
+        find_and_replace(model_path, "fuel.ignitionrobotics", "fuel.gazebosim", "*.mtl")
+        model_url = '{}/{}/{}/models/{}'.format(base_url, fuel_version, owner_name, model_name)
+        token_header = 'Private-Token: {}'.format(private_token)
+        print("Uploading model {}".format(model_name))
+        subprocess.call(['gz', 'fuel', 'edit', '-u', model_url, '-o', owner_name, '--header', token_header, '-m', model_path])
+
+
+print('Done.')


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adding a script that will change ignition to gz for all assets that belong to a user.

Large models may fail to upload. I haven't figure out how to solve this. For these models, we'll have to manually upload them via the browser.

I need to add support for worlds.
 
## Test it

1. Create a private token via your settings page on app.gazebosim.org.
2. Run the script against yourself (you'll need some models associated with your fuel account).
```
python3 ./gz-update-assets.py -o USERNAME -t PRIVATE_TOKEN
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.