### PR TITLE
Forward Port: Disable tests that are known to fail on Windows (#387)

### DIFF
--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -1148,7 +1148,8 @@ TEST_F(FuelClientTest, DownloadWorld)
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
 // https://github.com/gazebosim/gz-fuel-tools/issues/106
-TEST_F(FuelClientTest, CachedWorld)
+// This is fixed in gz-fuel-tools9+, but not here to preserve behavior
+TEST_F(FuelClientTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(CachedWorld))
 {
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -1476,8 +1477,11 @@ TEST_F(FuelClientTest, UploadModelFail)
   EXPECT_EQ(ResultType::UPLOAD_ERROR, result.Type());
 }
 
-//////////////////////////////////////////////////
-TEST_F(FuelClientTest, PatchModelFail)
+/////////////////////////////////////////////////
+// Windows doesn't support colons in filenames
+// https://github.com/gazebosim/gz-fuel-tools/issues/106
+// This is fixed in gz-fuel-tools9+, but not here to preserve behavior
+TEST_F(FuelClientTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(PatchModelFail))
 {
   FuelClient client;
   ModelIdentifier modelId;

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -51,6 +51,10 @@ class CmdLine : public ::testing::Test
     // instead of on teardown leaves the folder intact for debugging if needed
     common::removeAll(testCachePath);
     ASSERT_TRUE(common::createDirectories(testCachePath));
+    ASSERT_TRUE(common::createDirectories(
+        common::joinPaths(testCachePath, "fuel.gazebosim.org")));
+    ASSERT_TRUE(common::createDirectories(
+        common::joinPaths(testCachePath, "fuel.ignitionrobotics.org")));
     setenv("GZ_FUEL_CACHE_PATH", this->testCachePath.c_str(), true);
   }
 


### PR DESCRIPTION
Forward port of https://github.com/gazebosim/gz-fuel-tools/pull/387
