### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,7 @@ set (GZ_TOOLS_VER 2)
 #============================================================================
 # Configure the build
 #============================================================================
-gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT)
+gz_configure_build(QUIT_IF_BUILD_ERRORS)
 
 #============================================================================
 # gz command line support


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166