### PR TITLE
Merge 8 ➡️ 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Ubuntu CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'ign-fuel-tools[0-9]'
+      - 'gz-fuel-tools[0-9]?'
+      - 'main'
 
 jobs:
   jammy-ci:
@@ -8,7 +14,7 @@ jobs:
     name: Ubuntu Jammy CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/gazebosim/projects/7
           github-token: ${{ secrets.TRIAGE_TOKEN }}
-

--- a/Changelog.md
+++ b/Changelog.md
@@ -370,6 +370,17 @@
 1. Support link referral download
     * [Pull request #333](https://github.com/gazebosim/gz-fuel-tools/pull/333)
 
+### Gazebo Fuel Tools 4.9.1 (2024-01-05)
+
+1. Create directories and more output on fail
+    * [Pull request #392](https://github.com/gazebosim/gz-fuel-tools/pull/392)
+
+1. Update github action workflows
+    * [Pull request #388](https://github.com/gazebosim/gz-fuel-tools/pull/388)
+
+1. Zip: use non-deprecated methods
+    * [Pull request #360](https://github.com/gazebosim/gz-fuel-tools/pull/360)
+
 ### Gazebo Fuel Tools 4.9.0 (2023-05-03)
 
 1. Add bash completion

--- a/src/FuelClient_TEST.cc
+++ b/src/FuelClient_TEST.cc
@@ -1159,7 +1159,8 @@ TEST_F(FuelClientTest, DownloadWorld)
 /////////////////////////////////////////////////
 // Windows doesn't support colons in filenames
 // https://github.com/gazebosim/gz-fuel-tools/issues/106
-TEST_F(FuelClientTest, CachedWorld)
+// This is fixed in gz-fuel-tools9+, but not here to preserve behavior
+TEST_F(FuelClientTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(CachedWorld))
 {
   ClientConfig config;
   config.SetCacheLocation(common::joinPaths(common::cwd(), "test_cache"));
@@ -1490,8 +1491,11 @@ TEST_F(FuelClientTest, UploadModelFail)
   EXPECT_EQ(ResultType::UPLOAD_ERROR, result.Type());
 }
 
-//////////////////////////////////////////////////
-TEST_F(FuelClientTest, PatchModelFail)
+/////////////////////////////////////////////////
+// Windows doesn't support colons in filenames
+// https://github.com/gazebosim/gz-fuel-tools/issues/106
+// This is fixed in gz-fuel-tools9+, but not here to preserve behavior
+TEST_F(FuelClientTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(PatchModelFail))
 {
   FuelClient client;
   ModelIdentifier modelId;

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -51,6 +51,8 @@ class CmdLine : public ::testing::Test
     // instead of on teardown leaves the folder intact for debugging if needed
     common::removeAll(testCachePath);
     ASSERT_TRUE(common::createDirectories(testCachePath));
+    ASSERT_TRUE(common::createDirectories(
+        common::joinPaths(testCachePath, "fuel.gazebosim.org")));
     setenv("GZ_FUEL_CACHE_PATH", this->testCachePath.c_str(), true);
   }
 
@@ -85,7 +87,7 @@ TEST_F(CmdLine, ModelListFail)
 
   EXPECT_NE(this->stdOutBuffer.str().find("Invalid URL"),
       std::string::npos) << this->stdOutBuffer.str();
-  EXPECT_TRUE(this->stdErrBuffer.str().empty());
+  EXPECT_TRUE(this->stdErrBuffer.str().empty()) << this->stdErrBuffer.str();
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# ➡️ Forward port

Port `gz-fuel-tools8` to `gz-fuel-tools9`

Branch comparison: https://github.com/gazebosim/gz-fuel-tools/compare/gz-fuel-tools9...gz-fuel-tools8

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)