### PR TITLE
Use config.yaml file from default cache location, if it exists

### DIFF
--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -228,9 +228,14 @@ ClientConfig::ClientConfig() : dataPtr(new ClientConfigPrivate)
       this->SetCacheLocation(gzFuelPath);
   }
 
-  std::string configFile = common::joinPaths(this->CacheLocation(), "config.yaml");
-  if (gz::common::exists(configFile))
-    this->LoadConfig(configFile);
+  std::string configYamlFile = common::joinPaths(this->CacheLocation(),
+                                                 "config.yaml");
+  std::string configYmlFile = common::joinPaths(this->CacheLocation(),
+                                                "config.yml");
+  if (gz::common::exists(configYamlFile))
+    this->LoadConfig(configYamlFile);
+  else if (gz::common::exists(configYmlFile))
+    this->LoadConfig(configYmlFile);
 }
 
 //////////////////////////////////////////////////

--- a/src/ClientConfig.cc
+++ b/src/ClientConfig.cc
@@ -218,18 +218,19 @@ ClientConfig::ClientConfig() : dataPtr(new ClientConfigPrivate)
              << "to set cache path. Please use [GZ_FUEL_CACHE_PATH] instead."
              << std::endl;
     }
-    else
-    {
-      return;
-    }
   }
 
-  if (!gz::common::isDirectory(gzFuelPath))
+  if (!gzFuelPath.empty())
   {
-    gzerr << "[" << gzFuelPath << "] is not a directory" << std::endl;
-    return;
+    if (!gz::common::isDirectory(gzFuelPath))
+      gzerr << "[" << gzFuelPath << "] is not a directory" << std::endl;
+    else
+      this->SetCacheLocation(gzFuelPath);
   }
-  this->SetCacheLocation(gzFuelPath);
+
+  std::string configFile = common::joinPaths(this->CacheLocation(), "config.yaml");
+  if (gz::common::exists(configFile))
+    this->LoadConfig(configFile);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary

This reads the `config.yaml` or `config.yml` file from the cache directory when the ClientConfig is created. Without this change, a user needs to enter the `-c` command line argument each time or manually call the `LoadConfig` function.

## Test it

1. Create an API key from app.gazebosim.org
2. Create a config.yaml file in `~/.gz/fuel` that contains:
```
---
servers:
  -
    url: https://fuel.gazebosim.org
    private-token: YOUR_API_KEY
```
3. Download a private model with something like `gz fuel download -u https://fuel.gazebosim.org/1.0/OWNER/models/MODEL`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.