### PR TITLE
Add Private function to world identifier

### DIFF
--- a/include/gz/fuel_tools/WorldIdentifier.hh
+++ b/include/gz/fuel_tools/WorldIdentifier.hh
@@ -156,7 +156,7 @@ namespace gz
       public: bool Private() const;
 
       /// \brief Set the privacy setting of the world.
-      /// \param[in] True indicates the world is private, false indicates the
+      /// \param[in] _private True indicates the world is private, false indicates the
       /// world is public.
       public: void SetPrivate(bool _private);
 

--- a/include/gz/fuel_tools/WorldIdentifier.hh
+++ b/include/gz/fuel_tools/WorldIdentifier.hh
@@ -150,6 +150,16 @@ namespace gz
       /// \return World information string
       public: std::string AsPrettyString(const std::string &_prefix = "") const;
 
+      /// \brief Returns the privacy setting of the world.
+      /// \return True if the world is private, false if the world is
+      /// public.
+      public: bool Private() const;
+
+      /// \brief Set the privacy setting of the world.
+      /// \param[in] True indicates the world is private, false indicates the
+      /// world is public.
+      public: void SetPrivate(bool _private);
+
       /// \brief PIMPL
       private: std::unique_ptr<WorldIdentifierPrivate> dataPtr;
     };

--- a/include/gz/fuel_tools/WorldIdentifier.hh
+++ b/include/gz/fuel_tools/WorldIdentifier.hh
@@ -156,8 +156,8 @@ namespace gz
       public: bool Private() const;
 
       /// \brief Set the privacy setting of the world.
-      /// \param[in] _private True indicates the world is private, false indicates the
-      /// world is public.
+      /// \param[in] _private True indicates the world is private,
+      /// false indicates the world is public.
       public: void SetPrivate(bool _private);
 
       /// \brief PIMPL

--- a/src/WorldIdentifier.cc
+++ b/src/WorldIdentifier.cc
@@ -43,8 +43,12 @@ class gz::fuel_tools::WorldIdentifierPrivate
   /// \brief World version. Valid versions start from 1, 0 means the tip.
   public: unsigned int version{0};
 
-  /// \brief Path of this model in the local cache
+  /// \brief Path of this world in the local cache
   public: std::string localPath;
+
+  /// \brief True indicates the world is private, false indicates the
+  /// world is public.
+  public: bool privacy{false};
 };
 
 //////////////////////////////////////////////////
@@ -229,3 +233,14 @@ std::string WorldIdentifier::AsPrettyString(const std::string &_prefix) const
   return out.str();
 }
 
+//////////////////////////////////////////////////
+bool WorldIdentifier::Private() const
+{
+  return this->dataPtr->privacy;
+}
+
+//////////////////////////////////////////////////
+void WorldIdentifier::SetPrivate(bool _private)
+{
+  this->dataPtr->privacy = _private;
+}

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -37,6 +37,12 @@ TEST(WorldIdentifier, SetFields)
   EXPECT_EQ(std::string("hello"), id.Name());
   EXPECT_EQ(std::string("acai"), id.Owner());
   EXPECT_EQ(6u, id.Version());
+
+  EXPECT_FALSE(id.Private());
+  id.SetPrivate(true);
+  EXPECT_TRUE(id.Private());
+  id.SetPrivate(false);
+  EXPECT_FALSE(id.Private());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary

Adds Private functions to WorldIdentifier. This will help facilitate world upload, which is coming in a follow up PR.

## Test it

Run the WorldIdentifier_TEST unit tet.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.