### PR TITLE
Migrate curl_formadd from form API to mime API (deprecated in Ubuntu Noble)

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -124,13 +124,13 @@ size_t RestWriteMemoryCallback(void *_buffer, size_t _size, size_t _nmemb,
 }
 
 /////////////////////////////////////////////////
-struct curl_httppost *BuildFormPost(
+void AddFormPost(
+    curl_mime * const multipart,
     const std::multimap<std::string, std::string> &_form)
 {
-  struct curl_httppost *formpost = nullptr;
-  struct curl_httppost *lastptr = nullptr;
   for (const auto &[key, value] : _form)
   {
+    curl_mimepart *part = curl_mime_addpart(multipart);
     // follow same convention as curl cmdline tool
     // field starting with @ indicates path to file to upload
     // others are standard fields to describe the file
@@ -171,26 +171,17 @@ struct curl_httppost *BuildFormPost(
         }
       }
 
-      curl_formadd(&formpost,
-          &lastptr,
-          CURLFORM_COPYNAME, key.c_str(),
-          CURLFORM_FILENAME, uploadFilename.c_str(),
-          CURLFORM_FILE, path.c_str(),
-          CURLFORM_CONTENTTYPE, contentType.c_str(),
-          CURLFORM_END);
+      curl_mime_name(part, key.c_str());
+      curl_mime_filename(part, uploadFilename.c_str());
+      curl_mime_filedata(part, path.c_str());
+      curl_mime_type(part, contentType.c_str());
     }
     else
     {
-      // standard key:value fields
-      curl_formadd(&formpost,
-          &lastptr,
-          CURLFORM_COPYNAME, key.c_str(),
-          CURLFORM_COPYCONTENTS, value.c_str(),
-          CURLFORM_END);
+      curl_mime_name(part, key.c_str());
+      curl_mime_data(part, value.c_str(), CURL_ZERO_TERMINATED);
     }
   }
-
-  return formpost;
 }
 
 /////////////////////////////////////////////////
@@ -293,7 +284,7 @@ RestResponse Rest::Request(HttpMethod _method,
   curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
 
   std::ifstream ifs;
-  struct curl_httppost *formpost = nullptr;
+  curl_mime *multipart = curl_mime_init(curl);
 
   // Send the request.
   if (_method == HttpMethod::GET)
@@ -302,9 +293,11 @@ RestResponse Rest::Request(HttpMethod _method,
   }
   else if (_method == HttpMethod::PATCH_FORM)
   {
-    formpost = BuildFormPost(_form);
+    AddFormPost(multipart, _form);
+
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
-    curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
+
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, multipart);
   }
   else if (_method == HttpMethod::POST)
   {
@@ -313,8 +306,7 @@ RestResponse Rest::Request(HttpMethod _method,
   }
   else if (_method == HttpMethod::POST_FORM)
   {
-    formpost = BuildFormPost(_form);
-    curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
+    AddFormPost(multipart, _form);
   }
   else if (_method == HttpMethod::DELETE)
   {
@@ -354,9 +346,6 @@ RestResponse Rest::Request(HttpMethod _method,
   // Update the header data.
   res.headers = headerData;
 
-  if (formpost)
-    curl_formfree(formpost);
-
   // free encoded path char*
   if (encodedPath)
     curl_free(encodedPath);
@@ -365,6 +354,7 @@ RestResponse Rest::Request(HttpMethod _method,
   curl_slist_free_all(headers);
 
   // Cleaning.
+  curl_mime_free(multipart);
   curl_easy_cleanup(curl);
 
   if (ifs.is_open())

--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -308,6 +308,7 @@ RestResponse Rest::Request(HttpMethod _method,
   else if (_method == HttpMethod::POST_FORM)
   {
     AddFormPost(multipart, _form);
+    curl_easy_setopt(curl, CURLOPT_MIMEPOST, multipart);
   }
   else if (_method == HttpMethod::DELETE)
   {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The new curl 8.x series deprecate part of the CURL API that is being used in fuel-tools. I was totally new to the CURL APIs but there was a good documentation on how to migrate the old form API to the new MIME API in https://curl.se/libcurl/c/libcurl-tutorial.html (search by Converting from deprecated form api to mime api) so I went ahead and try to get the thing working.

I don't see any new test failure but probably we need someone with more knowledge of fuel to review that things are actually working.

I ran the ASAN analizer but found that we already have problems on the ASAN build (although Jenkins is not reporting them probably because https://github.com/gazebosim/gz-cmake/issues/240). 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.