### PR TITLE
Clean all ASAN reported memory problems (curl related)

### DIFF
--- a/src/RestClient.cc
+++ b/src/RestClient.cc
@@ -223,6 +223,7 @@ RestResponse Rest::Request(HttpMethod _method,
 
     encodedPath = curl_easy_escape(curl, decodedPath, decodedSize);
     url = RestJoinUrl(url, encodedPath);
+    curl_free(decodedPath);
   }
 
   // Process query strings.

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -16,6 +16,7 @@
 */
 
 #include <curl/curl.h>
+#include <curl/easy.h>
 #include <string.h>
 #include <tinyxml2.h>
 
@@ -138,6 +139,7 @@ extern "C" void uglyPrint(
                 << std::string(encodedRes) << std::endl;
     }
   }
+  curl_easy_cleanup(curl);
 }
 
 //////////////////////////////////////////////////

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -137,6 +137,7 @@ extern "C" void uglyPrint(
       std::cout << _serverConfig.Url().Str() << "/" << _serverConfig.Version()
                 << "/" << owner->first << "/" << _resourceType << "/"
                 << std::string(encodedRes) << std::endl;
+      curl_free(encodedRes);
     }
   }
   curl_easy_cleanup(curl);

--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -47,7 +47,7 @@ std::string custom_exec_str(std::string _cmd)
   return result;
 }
 
-auto g_version = std::string(strdup(GZ_FUEL_TOOLS_VERSION_FULL));
+auto g_version = std::string(GZ_FUEL_TOOLS_VERSION_FULL);
 auto g_exec = std::string(GZ_PATH);
 auto g_listCmd = g_exec + " fuel list -v 4 --force-version " + g_version;
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The current ASAN build reports quite a few problems related to memory not being freed. I think that I've hunted mos of them if not all. 

Although our Jenkins ASAN builds are not repotring failures from these kind of problems (need to solve https://github.com/gazebosim/gz-cmake/issues/240) they are easy visible from the logs, see the failures for this branch before this PR in: https://build.osrfoundation.org/job/gz_fuel_tools-ci_asan-gz-fuel-tools9-jammy-amd64/31/consoleFull (grep by "LeakSanitizer: detected memory leaks").

If the PR is good and there are no more problems, this testing build should be clean: https://build.osrfoundation.org/job/_test_gz_fuel_tools-ci_asan-gz-fuel-tools9-jammy-amd64/2/consoleFull


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.