### PR TITLE
Fix tests pulling from wrong server

### DIFF
--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -98,7 +98,7 @@ TEST(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ListFail))
 TEST(CmdLine,
     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListConfigServerUgly))
 {
-  auto output = custom_exec_str(g_listCmd + " -t model --raw");
+  auto output = custom_exec_str(g_listCmd + " -t model --raw -u 'https://fuel.gazebosim.org' -o openrobotics");
   EXPECT_NE(output.find("https://fuel.gazebosim.org/1.0/"),
             std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -98,7 +98,7 @@ TEST_F(CmdLine, ModelListFail)
 // https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(CmdLine, ModelListConfigServerUgly)
 {
-  EXPECT_TRUE(listModels("", "openroboticstest", "true"));
+  EXPECT_TRUE(listModels("https://fuel.gazebosim.org", "openroboticstest", "true"));
 
   EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();


### PR DESCRIPTION
# 🦟 Bug fix
Fixes Fuel_tools4 CI and Fuel_tools7 CI

Reference builds: 
https://build.osrfoundation.org/job/gz_fuel_tools-ci-ign-fuel-tools4-focal-amd64/41/
https://build.osrfoundation.org/job/gz_fuel_tools-ci-ign-fuel-tools7-focal-amd64/48/

## Summary
I don't think this has been reported, but Citadel and Fortress CI has been failing on Linux to run some tests requiring to download some models. The tests fail with timeouts, but the problem is that the server url is not configured properly, and so it's not capable of downloading anything. 

I fixed this by using the same configuration as in more recent distributions. This will require a Forward Port to Fortress after it gets merged. FYI @Crola1702 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.