### PR TITLE
Fix tests pulling from wrong server (#421)

### DIFF
--- a/src/gz_TEST.cc
+++ b/src/gz_TEST.cc
@@ -98,7 +98,7 @@ TEST(CmdLine, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ListFail))
 TEST(CmdLine,
     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ModelListConfigServerUgly))
 {
-  auto output = custom_exec_str(g_listCmd + " -t model --raw");
+  auto output = custom_exec_str(g_listCmd + " -t model --raw -u 'https://fuel.gazebosim.org' -o openrobotics");
   EXPECT_NE(output.find("https://fuel.gazebosim.org/1.0/"),
             std::string::npos) << output;
   EXPECT_EQ(output.find("owners"), std::string::npos) << output;

--- a/src/gz_src_TEST.cc
+++ b/src/gz_src_TEST.cc
@@ -98,7 +98,7 @@ TEST_F(CmdLine, ModelListFail)
 // https://github.com/gazebosim/gz-fuel-tools/issues/105
 TEST_F(CmdLine, ModelListConfigServerUgly)
 {
-  EXPECT_TRUE(listModels("", "openroboticstest", "true"));
+  EXPECT_TRUE(listModels("https://fuel.gazebosim.org", "openroboticstest", "true"));
 
   EXPECT_NE(this->stdOutBuffer.str().find("https://fuel.gazebosim.org"),
       std::string::npos) << this->stdOutBuffer.str();


### PR DESCRIPTION
# FORWARD PORT

Forward port #421 to fix same error on fuel_tools7. FYI @Crola1702 

## Summary
As the title says

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.