### PR TITLE
Add Url accessor to Identifiers

### DIFF
--- a/include/gz/fuel_tools/CollectionIdentifier.hh
+++ b/include/gz/fuel_tools/CollectionIdentifier.hh
@@ -92,6 +92,10 @@ namespace gz::fuel_tools
     /// \return Unique collection name.
     public: std::string UniqueName() const;
 
+    /// \brief Returns a URL for the collection.
+    /// \remarks this is Server/Owner/Name.
+    public: gz::common::URI Url() const;
+
     /// \brief Returns all the collection information as a string. Convenient
     /// for debugging.
     /// \param[in] _prefix Optional prefix for every line of the string.

--- a/include/gz/fuel_tools/ModelIdentifier.hh
+++ b/include/gz/fuel_tools/ModelIdentifier.hh
@@ -84,6 +84,10 @@ namespace gz::fuel_tools
     /// \return Unique model name.
     public: std::string UniqueName() const;
 
+    /// \brief Returns a URL for the model.
+    /// \remarks this is Server/Owner/Name.
+    public: gz::common::URI Url() const;
+
     /// \brief set the name of the model.
     /// \param[in] _name The name to set. Must be ascii and pass [-_a-z0-9]+.
     /// \return true if successful.

--- a/include/gz/fuel_tools/WorldIdentifier.hh
+++ b/include/gz/fuel_tools/WorldIdentifier.hh
@@ -131,6 +131,10 @@ namespace gz::fuel_tools
     /// \return Unique world name.
     public: std::string UniqueName() const;
 
+    /// \brief Returns a URL for the world.
+    /// \remarks this is Server/Owner/Name.
+    public: gz::common::URI Url() const;
+
     // /// \brief Sets the SHA 2 256 hash of the world
     // /// \param[in] _hash a 256 bit SHA 2 hash
     // /// \returns true if successful

--- a/src/CollectionIdentifier.cc
+++ b/src/CollectionIdentifier.cc
@@ -77,6 +77,16 @@ std::string CollectionIdentifier::UniqueName() const
 }
 
 //////////////////////////////////////////////////
+gz::common::URI CollectionIdentifier::Url() const
+{
+  return common::URI(
+    common::joinPaths(this->dataPtr->server.Url().Str(),
+                      this->dataPtr->owner,
+                      "collections",
+                      this->dataPtr->name), true);
+}
+
+//////////////////////////////////////////////////
 std::string CollectionIdentifier::Name() const
 {
   return this->dataPtr->name;

--- a/src/CollectionIdentifier_TEST.cc
+++ b/src/CollectionIdentifier_TEST.cc
@@ -44,7 +44,6 @@ TEST(CollectionIdentifier, SetFields)
 
 /////////////////////////////////////////////////
 /// \brief Unique Name
-// See https://github.com/gazebosim/gz-fuel-tools/issues/231
 TEST(CollectionIdentifier, UniqueName)
 {
   gz::fuel_tools::ServerConfig srv1;
@@ -67,6 +66,32 @@ TEST(CollectionIdentifier, UniqueName)
 
   id.SetServer(srv3);
   EXPECT_EQ("https://localhost:8003/alice/collections/hello", id.UniqueName());
+}
+
+/////////////////////////////////////////////////
+/// \brief Unique Name
+TEST(CollectionIdentifier, Url)
+{
+  gz::fuel_tools::ServerConfig srv1;
+  srv1.SetUrl(common::URI("https://localhost:8001", true));
+
+  gz::fuel_tools::ServerConfig srv2;
+  srv2.SetUrl(common::URI("https://localhost:8002", true));
+
+  gz::fuel_tools::ServerConfig srv3;
+  srv3.SetUrl(common::URI("https://localhost:8003", true));
+
+  CollectionIdentifier id;
+  id.SetName("hello");
+  id.SetOwner("alice");
+  id.SetServer(srv1);
+  EXPECT_EQ("https://localhost:8001/alice/collections/hello", id.Url().Str());
+
+  id.SetServer(srv2);
+  EXPECT_EQ("https://localhost:8002/alice/collections/hello", id.Url().Str());
+
+  id.SetServer(srv3);
+  EXPECT_EQ("https://localhost:8003/alice/collections/hello", id.Url().Str());
 }
 
 /////////////////////////////////////////////////

--- a/src/ModelIdentifier.cc
+++ b/src/ModelIdentifier.cc
@@ -156,6 +156,16 @@ std::string ModelIdentifier::UniqueName() const
 }
 
 //////////////////////////////////////////////////
+common::URI ModelIdentifier::Url() const
+{
+  return common::URI(
+    common::joinPaths(this->dataPtr->server.Url().Str(),
+                      this->dataPtr->owner,
+                      "models",
+                      this->dataPtr->name), true);
+}
+
+//////////////////////////////////////////////////
 std::string ModelIdentifier::Name() const
 {
   return this->dataPtr->name;

--- a/src/ModelIdentifier_TEST.cc
+++ b/src/ModelIdentifier_TEST.cc
@@ -81,6 +81,32 @@ TEST(ModelIdentifier, UniqueName)
 }
 
 /////////////////////////////////////////////////
+/// \brief Url
+TEST(ModelIdentifier, Url)
+{
+  gz::fuel_tools::ServerConfig srv1;
+  srv1.SetUrl(common::URI("https://localhost:8001", true));
+
+  gz::fuel_tools::ServerConfig srv2;
+  srv2.SetUrl(common::URI("https://localhost:8002", true));
+
+  gz::fuel_tools::ServerConfig srv3;
+  srv3.SetUrl(common::URI("https://localhost:8003", true));
+
+  ModelIdentifier id;
+  id.SetName("hello");
+  id.SetOwner("alice");
+  id.SetServer(srv1);
+  EXPECT_EQ("https://localhost:8001/alice/models/hello", id.Url().Str());
+
+  id.SetServer(srv2);
+  EXPECT_EQ("https://localhost:8002/alice/models/hello", id.Url().Str());
+
+  id.SetServer(srv3);
+  EXPECT_EQ("https://localhost:8003/alice/models/hello", id.Url().Str());
+}
+
+/////////////////////////////////////////////////
 /// \brief Copy constructor deep copies
 TEST(ModelIdentifier, CopyConstructorDeepCopy)
 {

--- a/src/WorldIdentifier.cc
+++ b/src/WorldIdentifier.cc
@@ -92,6 +92,16 @@ std::string WorldIdentifier::UniqueName() const
 }
 
 //////////////////////////////////////////////////
+gz::common::URI WorldIdentifier::Url() const
+{
+  return common::URI(
+    common::joinPaths(this->dataPtr->server.Url().Str(),
+                      this->dataPtr->owner,
+                      "worlds",
+                      this->dataPtr->name), true);
+}
+
+//////////////////////////////////////////////////
 std::string WorldIdentifier::Name() const
 {
   return this->dataPtr->name;

--- a/src/WorldIdentifier_TEST.cc
+++ b/src/WorldIdentifier_TEST.cc
@@ -73,6 +73,33 @@ TEST(WorldIdentifier, UniqueName)
 }
 
 /////////////////////////////////////////////////
+/// \brief Url
+TEST(WorldIdentifier, Url)
+{
+  gz::fuel_tools::ServerConfig srv1;
+  srv1.SetUrl(gz::common::URI("https://localhost:8001/", true));
+
+  gz::fuel_tools::ServerConfig srv2;
+  srv2.SetUrl(gz::common::URI("https://localhost:8002", true));
+
+  gz::fuel_tools::ServerConfig srv3;
+  srv3.SetUrl(gz::common::URI("https://localhost:8003/", true));
+
+  WorldIdentifier id;
+  id.SetName("hello");
+  id.SetOwner("alice");
+
+  id.SetServer(srv1);
+  EXPECT_EQ("https://localhost:8001/alice/worlds/hello", id.Url().Str());
+
+  id.SetServer(srv2);
+  EXPECT_EQ("https://localhost:8002/alice/worlds/hello", id.Url().Str());
+
+  id.SetServer(srv3);
+  EXPECT_EQ("https://localhost:8003/alice/worlds/hello", id.Url().Str());
+}
+
+/////////////////////////////////////////////////
 /// \brief Copy constructor deep copies
 TEST(WorldIdentifier, CopyConstructorDeepCopy)
 {


### PR DESCRIPTION
Previously we were relying on UniqueName to hold a Url. UniqueName was updated to generate filesystem-safe paths for both Linux and Windows, so it no longer holds a valid Url.  This adds a peer method to also retrieve the Url of the Model/World/Collection.