### PR TITLE
Fix GCC warnings

### DIFF
--- a/src/FuelClient.cc
+++ b/src/FuelClient.cc
@@ -1901,7 +1901,7 @@ bool FuelClient::UpdateModels(const std::vector<std::string> &_headers)
   }
 
   // Attempt to update each model.
-  for (const auto id : toProcess)
+  for (const auto &id : toProcess)
   {
     ignition::fuel_tools::ModelIdentifier cloudId;
 
@@ -1942,7 +1942,7 @@ bool FuelClient::UpdateWorlds(const std::vector<std::string> &_headers)
   }
 
   // Attempt to update each world.
-  for (const auto id : toProcess)
+  for (const auto &id : toProcess)
   {
     ignition::fuel_tools::WorldIdentifier cloudId;
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Fix gcc warnings in a few places where GCC was complaining about iterating over values instead of reference.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
