### PR TITLE
Add missing URI header files

### DIFF
--- a/src/CollectionIdentifier.cc
+++ b/src/CollectionIdentifier.cc
@@ -20,9 +20,11 @@
 #include <vector>
 
 #include <gz/common/Filesystem.hh>
+#include <gz/common/URI.hh>
 
 #include "gz/fuel_tools/ClientConfig.hh"
 #include "gz/fuel_tools/CollectionIdentifier.hh"
+#include "gz/fuel_tools/Helpers.hh"
 
 
 namespace gz::fuel_tools

--- a/src/WorldIdentifier.cc
+++ b/src/WorldIdentifier.cc
@@ -21,6 +21,7 @@
 
 #include <gz/common/Filesystem.hh>
 #include <gz/common/StringUtils.hh>
+#include <gz/common/URI.hh>
 #include <gz/common/Util.hh>
 
 #include "gz/fuel_tools/ClientConfig.hh"


### PR DESCRIPTION
# 🦟 Bug fix

Fixes clang-tidy warnings related to types used without their header files.

## Summary

Add missing includes for `gz::common::URI` and `gz::fuel_tools::uriToPath`

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
