### PR TITLE
Prepare for 10.0.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
 #============================================================================
 # Configure the project
 #============================================================================
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,13 @@
 
 ### Gazebo Fuel Tools 10.0.0 (2024-09-XX)
 
-Changes since 9.1.0
+1. **Baseline:** this includes all changes from 9.1.0 and earlier.
+
+1. Update badges to point to gz-fuel-tools10
+    * [Pull request #439](https://github.com/gazebosim/gz-fuel-tools/pull/439)
+
+1. Ionic changelog
+    * [Pull request #438](https://github.com/gazebosim/gz-fuel-tools/pull/438)
 
 1. Require cmake 3.22.1
     * [Pull request #436](https://github.com/gazebosim/gz-fuel-tools/pull/436)


### PR DESCRIPTION

# 🎈 Release

Preparation for 10.0.0~pre1 release.

Comparison to 9.1.0: https://github.com/gazebosim/gz-fuel-tools/compare/gz-fuel-tools9_9.1.0...prep_10.0.0pre1


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
