### PR TITLE
Fixed cmd on Windows

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -31,7 +31,15 @@ set(cmd_script_configured "${CMAKE_CURRENT_BINARY_DIR}/${CMD_NAME}${PROJECT_VERS
 
 # Set the library_location variable to the relative path to the library file
 # within the install directory structure.
-set(library_location "../../../${CMAKE_INSTALL_LIBDIR}/$<TARGET_FILE_NAME:${PROJECT_LIBRARY_TARGET_NAME}>")
+if (MSVC)
+  set(library_location_prefix "${CMAKE_INSTALL_BINDIR}")
+else()
+  set(library_location_prefix "${CMAKE_INSTALL_LIBDIR}")
+endif()
+
+# Set the library_location variable to the relative path to the library file
+# within the install directory structure.
+set(library_location "../../../${library_location_prefix}/$<TARGET_FILE_NAME:${PROJECT_LIBRARY_TARGET_NAME}>")
 
 configure_file(
   "${CMD_NAME}.rb.in"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The cmd file installed on Windows points to a non-existent directory:

    LIBRARY_NAME = '../../../lib/gz-fuel_tools10.dll'

Whereas the dll is in bin, not lib.

This PR copies the logic from gz-sim and sdformat.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.