### PR TITLE
Fix return value when download fails

### DIFF
--- a/example/download.cc
+++ b/example/download.cc
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
       id.SetServer(server);
 
       // Download and return 0 only if success
-      if (client.DownloadWorld(id).Type() ==  gz::fuel_tools::ResultType::FETCH)
+      if (client.DownloadWorld(id).Type() == gz::fuel_tools::ResultType::FETCH)
       {
         return 0;
       }

--- a/example/download.cc
+++ b/example/download.cc
@@ -109,9 +109,11 @@ int main(int argc, char **argv)
       auto id = modelIdentifier;
       id.SetServer(server);
 
-      // Download
-      if (client.DownloadModel(id))
+      // Download and return 0 only if success
+      if (client.DownloadModel(id).Type() == ResultType::FETCH)
+      {
         return 0;
+      }
     }
     else if (FLAGS_t == "world")
     {
@@ -119,9 +121,11 @@ int main(int argc, char **argv)
       auto id = worldIdentifier;
       id.SetServer(server);
 
-      // Download
-      if (client.DownloadWorld(id))
+      // Download and return 0 only if success
+      if (client.DownloadWorld(id).Type() == ResultType::FETCH)
+      {
         return 0;
+      }
     }
   }
 

--- a/example/download.cc
+++ b/example/download.cc
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
       id.SetServer(server);
 
       // Download and return 0 only if success
-      if (client.DownloadModel(id).Type() == ResultType::FETCH)
+      if (client.DownloadModel(id).Type() ==  gz::fuel_tools::ResultType::FETCH)
       {
         return 0;
       }
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
       id.SetServer(server);
 
       // Download and return 0 only if success
-      if (client.DownloadWorld(id).Type() == ResultType::FETCH)
+      if (client.DownloadWorld(id).Type() ==  gz::fuel_tools::ResultType::FETCH)
       {
         return 0;
       }

--- a/example/download.cc
+++ b/example/download.cc
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
       id.SetServer(server);
 
       // Download and return 0 only if success
-      if (client.DownloadModel(id).Type() ==  gz::fuel_tools::ResultType::FETCH)
+      if (client.DownloadModel(id).Type() == gz::fuel_tools::ResultType::FETCH)
       {
         return 0;
       }

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -528,9 +528,10 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
       result = client.DownloadModel(model);
     }
 
-    if (!result)
+    if (result != gz::fuel_tools::ResultType::FETCH)
     {
-      std::cout << "Download failed." << std::endl;
+      std::cout << "Download failed because " << result.ReadableResult()
+        << std::endl;
       return false;
     }
   }
@@ -553,7 +554,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
 
     gz::fuel_tools::Result result = client.DownloadWorld(world);
 
-    if (!result)
+    if (result != gz::fuel_tools::ResultType::FETCH)
     {
       std::cout << "Download failed because " << result.ReadableResult()
         << std::endl;

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -516,7 +516,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
               << std::endl;
     }
 
-    int result = 0;
+    gz::fuel_tools::Result result(gz::fuel_tools::ResultType::UNKNOWN);
     if (_header && strlen(_header) > 0)
     {
       std::vector<std::string> headers;

--- a/src/gz.cc
+++ b/src/gz.cc
@@ -528,7 +528,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
       result = client.DownloadModel(model);
     }
 
-    if (result != gz::fuel_tools::ResultType::FETCH)
+    if (result.Type() != gz::fuel_tools::ResultType::FETCH)
     {
       std::cout << "Download failed because " << result.ReadableResult()
         << std::endl;
@@ -554,7 +554,7 @@ extern "C" GZ_FUEL_TOOLS_VISIBLE int downloadUrl(const char *_url,
 
     gz::fuel_tools::Result result = client.DownloadWorld(world);
 
-    if (result != gz::fuel_tools::ResultType::FETCH)
+    if (result.Type() != gz::fuel_tools::ResultType::FETCH)
     {
       std::cout << "Download failed because " << result.ReadableResult()
         << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

## Issue number: 349

## Summary
Fixed an issue where the download utility returning a success, even if the actual download fails. Main causes appeared to be some seemingly unintended typecasting between `int` and `gz::fuel_tools::Result`, as well as not checking if the result value was actually a success or not.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
