### PR TITLE
ci: run cppcheck, cpplint, doxygen on noble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
-          cppcheck-enabled: true
-          cpplint-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -31,3 +29,8 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+        with:
+          # codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true

--- a/include/gz/fuel_tools/Helpers.hh
+++ b/include/gz/fuel_tools/Helpers.hh
@@ -43,7 +43,7 @@ namespace gz::fuel_tools
 /// It encodes illegal characters on Windows and Linux filesystems with
 /// their corresponding URL-encoded values.
 ///
-/// This assumes an authority of the form: username@host:port
+/// This assumes an authority of the form: `username@host:port`
 /// "@" is encoded as %40
 /// ":" is encoded as %3A
 ///

--- a/include/gz/fuel_tools/Model.hh
+++ b/include/gz/fuel_tools/Model.hh
@@ -81,7 +81,7 @@ namespace gz::fuel_tools
     public: Model(const Model &_orig) = default;
 
     /// \brief Protected constructor
-    /// \param[in] _dPtr Model private data to copy.
+    /// \param[in] _dptr Model private data to copy.
     protected: explicit Model(std::shared_ptr<ModelPrivate> _dptr);
 
     /// \brief Returns false if model was constructed via Model()

--- a/include/gz/fuel_tools/ModelIdentifier.hh
+++ b/include/gz/fuel_tools/ModelIdentifier.hh
@@ -149,8 +149,8 @@ namespace gz::fuel_tools
     public: bool Private() const;
 
     /// \brief Set the privacy setting of the model.
-    /// \param[in] True indicates the model is private, false indicates the
-    /// model is public.
+    /// \param[in] _private True indicates the model is private,
+    /// false indicates the model is public.
     public: void SetPrivate(bool _private) const;
 
     /// \brief Set the description of the model.

--- a/include/gz/fuel_tools/WorldIdentifier.hh
+++ b/include/gz/fuel_tools/WorldIdentifier.hh
@@ -122,7 +122,7 @@ namespace gz::fuel_tools
     public: std::string LocalPath() const;
 
     /// \brief Sets the path of the world in the local cache.
-    /// \param[in] Local path to world.
+    /// \param[in] _path Local path to world.
     /// \sa LocalPath
     public: bool SetLocalPath(const std::string &_path);
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1222

## Summary

Jammy isn't officially supported for Ionic, so move linters to use Noble, and enable doxygen checking.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
