### PR TITLE
Use gz-fuel-tools name for top level library target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,7 +55,7 @@ public_headers = public_headers_no_gen + [
 ]
 
 cc_library(
-    name = "fuel_tools",
+    name = "gz-fuel-tools",
     srcs = sources + private_headers,
     hdrs = public_headers,
     defines = [
@@ -101,7 +101,7 @@ test_sources = glob(
         "GZ_BAZEL": "1",
     },
     deps = [
-        ":fuel_tools",
+        ":gz-fuel-tools",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@gz-common",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -17,7 +17,7 @@ gz_configure_header(
     ],
     package_xml = "//:package.xml",
     deps = [
-        "//:fuel_tools",
+        "//:gz-fuel-tools",
         "@googletest//:gtest",
     ],
 )
@@ -35,7 +35,7 @@ gz_configure_header(
             "integration",
         ],
         deps = [
-            "//:fuel_tools",
+            "//:gz-fuel-tools",
             "@googletest//:gtest",
             "@googletest//:gtest_main",
             "@gz-common",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Use `gz-fuel-tools` name for top level library target instead of `fuel_tools` to be consistent with the module name and also the convention followed in other gz packages (e.g. `gz-common`: https://github.com/gazebosim/gz-common/blob/gz-common6/BUILD.bazel#L66).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

