### PR TITLE
Prepare for 11.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(gz-cmake REQUIRED)
 #============================================================================
 # Configure the project
 #============================================================================
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 ## Gazebo Fuel Tools 11.x
 
-### Gazebo Fuel Tools 11.0.0 (2025-09-XX)
+### Gazebo Fuel Tools 11.0.0 (2025-09-30)
 
 1. **Baseline:** this includes all changes from 10.1.0 and earlier.
+
+1. [Bazel] Update bazel module to use jetty release branches
+    * [Pull request #474](https://github.com/gazebosim/gz-fuel-tools/pull/474)
 
 1. Bump gz-cmake and others in jetty
     * [Pull request #464](https://github.com/gazebosim/gz-fuel-tools/pull/464)

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 1. [Bazel] Update bazel module to use jetty release branches
     * [Pull request #474](https://github.com/gazebosim/gz-fuel-tools/pull/474)
 
+1. Update gz-fuel-tools11 badge URLs
+    * [Pull request #473](https://github.com/gazebosim/gz-fuel-tools/pull/473)
+
 1. Bump gz-cmake and others in jetty
     * [Pull request #464](https://github.com/gazebosim/gz-fuel-tools/pull/464)
 


### PR DESCRIPTION

<!-- For maintainers only -->

# 🎈 Release

Preparation for 11.0.0 release.

Comparison to gz-fuel-tools~pre1: https://github.com/gazebosim/gz-fuel-tools/compare/gz-fuel-tools11_11.0.0-pre1...gz-fuel-tools11



## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
